### PR TITLE
HDDS-13034. Refactor Directory Deleting Service to use ReclaimableDirectoryFilter & ReclaimableKeyFilter

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -621,7 +621,7 @@ public final class OzoneConfigKeys {
 
   public static final String FS_TRASH_CLASSNAME = "fs.trash.classname";
   public static final String FS_TRASH_CLASSNAME_DEFAULT =
-      "org.apache.hadoop.ozone.om.TrashPolicyOzone";
+      "org.apache.hadoop.fs.ozone.OzoneTrashPolicy";
 
   public static final String
       OZONE_OM_SNAPSHOT_COMPACTION_DAG_MAX_TIME_ALLOWED =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3786,7 +3786,7 @@
   <property>
     <name>ozone.snapshot.directory.service.timeout</name>
     <value>300s</value>
-    <tag>OZONE, PERFORMANCE, OM</tag>
+    <tag>OZONE, PERFORMANCE, OM, DEPRECATED</tag>
     <description>
       Timeout value for SnapshotDirectoryCleaningService.
     </description>
@@ -3795,9 +3795,9 @@
   <property>
     <name>ozone.snapshot.directory.service.interval</name>
     <value>24h</value>
-    <tag>OZONE, PERFORMANCE, OM</tag>
+    <tag>OZONE, PERFORMANCE, OM, DEPRECATED</tag>
     <description>
-      The time interval between successive SnapshotDirectoryCleaningService
+      DEPRECATED. The time interval between successive SnapshotDirectoryCleaningService
       thread run.
     </description>
   </property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2789,7 +2789,7 @@
 
   <property>
     <name>fs.trash.classname</name>
-    <value>org.apache.hadoop.ozone.om.TrashPolicyOzone</value>
+    <value>org.apache.hadoop.fs.ozone.OzoneTrashPolicy</value>
     <tag>OZONE, OZONEFS, CLIENT</tag>
     <description>
       Trash Policy to be used.

--- a/hadoop-hdds/docs/content/interface/Ofs.md
+++ b/hadoop-hdds/docs/content/interface/Ofs.md
@@ -237,7 +237,7 @@ In order to enable trash in Ozone, Please add these configs to core-site.xml
 </property>
 <property>
   <name>fs.trash.classname</name>
-  <value>org.apache.hadoop.ozone.om.TrashPolicyOzone</value>
+  <value>org.apache.hadoop.fs.ozone.OzoneTrashPolicy</value>
 </property>
 {{< /highlight >}}
                                            

--- a/hadoop-hdds/docs/content/interface/Ofs.zh.md
+++ b/hadoop-hdds/docs/content/interface/Ofs.zh.md
@@ -220,7 +220,7 @@ $ ozone fs -put ./NOTICE.txt ofs://om/tmp/key1
 </property>
 <property>
   <name>fs.trash.classname</name>
-  <value>org.apache.hadoop.ozone.om.TrashPolicyOzone</value>
+  <value>org.apache.hadoop.fs.ozone.OzoneTrashPolicy</value>
 </property>
 {{< /highlight >}}
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -19,7 +19,9 @@ package org.apache.hadoop.hdds.scm.container.balancer;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
+import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -458,6 +460,23 @@ public class ContainerBalancer extends StatefulService {
       throw new InvalidContainerBalancerConfigurationException(
           "hdds.container.balancer.move.replication.timeout should " +
           "be less than hdds.container.balancer.move.timeout.");
+    }
+
+    // (move.timeout - move.replication.timeout - event.timeout.datanode.offset)
+    // should be greater than or equal to 9 minutes
+    long datanodeOffset = ozoneConfiguration.getTimeDuration("hdds.scm.replication.event.timeout.datanode.offset",
+        Duration.ofMinutes(6).toMillis(), TimeUnit.MILLISECONDS);
+    if ((conf.getMoveTimeout().toMillis() - conf.getMoveReplicationTimeout().toMillis() - datanodeOffset)
+        < Duration.ofMinutes(9).toMillis()) {
+      String msg = String.format("(hdds.container.balancer.move.timeout (%sms) - " +
+              "hdds.container.balancer.move.replication.timeout (%sms) - " +
+              "hdds.scm.replication.event.timeout.datanode.offset (%sms)) " +
+              "should be greater than or equal to 540000ms or 9 minutes.",
+          conf.getMoveTimeout().toMillis(),
+          conf.getMoveReplicationTimeout().toMillis(),
+          Duration.ofMillis(datanodeOffset).toMillis());
+      LOG.warn(msg);
+      throw new InvalidContainerBalancerConfigurationException(msg);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -205,6 +205,25 @@ public class TestContainerBalancer {
         () -> containerBalancer.startBalancer(balancerConfiguration),
         "hdds.container.balancer.move.replication.timeout should " +
             "be less than hdds.container.balancer.move.timeout.");
+    assertSame(ContainerBalancerTask.Status.STOPPED, containerBalancer.getBalancerStatus());
+
+    conf.setTimeDuration("hdds.container.balancer.move.timeout", 60,
+        TimeUnit.MINUTES);
+    conf.setTimeDuration(
+        "hdds.container.balancer.move.replication.timeout", 50,
+        TimeUnit.MINUTES);
+
+    balancerConfiguration =
+        conf.getObject(ContainerBalancerConfiguration.class);
+    InvalidContainerBalancerConfigurationException ex =
+        assertThrowsExactly(
+            InvalidContainerBalancerConfigurationException.class,
+            () -> containerBalancer.startBalancer(balancerConfiguration),
+            "(hdds.container.balancer.move.timeout - hdds.container.balancer.move.replication.timeout " +
+                "- hdds.scm.replication.event.timeout.datanode.offset) should be greater than or equal to 9 minutes.");
+    assertTrue(ex.getMessage().contains("should be greater than or equal to 540000ms or 9 minutes"),
+        "Exception message should contain 'should be greater than or equal to 540000ms or 9 minutes'");
+    assertSame(ContainerBalancerTask.Status.STOPPED, containerBalancer.getBalancerStatus());
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -387,6 +387,18 @@ public final class OMConfigKeys {
    */
   public static final String OZONE_SNAPSHOT_DEEP_CLEANING_ENABLED = "ozone.snapshot.deep.cleaning.enabled";
   public static final boolean OZONE_SNAPSHOT_DEEP_CLEANING_ENABLED_DEFAULT = false;
+  @Deprecated
+  public static final String OZONE_SNAPSHOT_DIRECTORY_SERVICE_INTERVAL =
+      "ozone.snapshot.directory.service.interval";
+  @Deprecated
+  public static final String OZONE_SNAPSHOT_DIRECTORY_SERVICE_INTERVAL_DEFAULT
+      = "24h";
+  @Deprecated
+  public static final String OZONE_SNAPSHOT_DIRECTORY_SERVICE_TIMEOUT =
+      "ozone.snapshot.directory.service.timeout";
+  @Deprecated
+  public static final String
+      OZONE_SNAPSHOT_DIRECTORY_SERVICE_TIMEOUT_DEFAULT = "300s";
 
   public static final String OZONE_THREAD_NUMBER_DIR_DELETION =
       "ozone.thread.number.dir.deletion";

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -387,14 +387,6 @@ public final class OMConfigKeys {
    */
   public static final String OZONE_SNAPSHOT_DEEP_CLEANING_ENABLED = "ozone.snapshot.deep.cleaning.enabled";
   public static final boolean OZONE_SNAPSHOT_DEEP_CLEANING_ENABLED_DEFAULT = false;
-  public static final String OZONE_SNAPSHOT_DIRECTORY_SERVICE_INTERVAL =
-      "ozone.snapshot.directory.service.interval";
-  public static final String OZONE_SNAPSHOT_DIRECTORY_SERVICE_INTERVAL_DEFAULT
-      = "24h";
-  public static final String OZONE_SNAPSHOT_DIRECTORY_SERVICE_TIMEOUT =
-      "ozone.snapshot.directory.service.timeout";
-  public static final String
-      OZONE_SNAPSHOT_DIRECTORY_SERVICE_TIMEOUT_DEFAULT = "300s";
 
   public static final String OZONE_THREAD_NUMBER_DIR_DELETION =
       "ozone.thread.number.dir.deletion";

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
@@ -27,7 +27,6 @@ ${VOLUME}           cli-debug-volume${PREFIX}
 ${BUCKET}           cli-debug-bucket
 ${DEBUGKEY}         debugKey
 ${TESTFILE}         testfile
-${OM_SERVICE_ID}    %{OM_SERVICE_ID}
 
 *** Keywords ***
 Write keys
@@ -38,7 +37,7 @@ Write keys
 
 *** Test Cases ***
 Test ozone debug replicas verify checksums
-    ${output} =    Execute   ozone debug replicas verify --checksums o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}/${TESTFILE} --output-dir ${TEMP_DIR}
+    ${output} =    Execute   ozone debug replicas verify --checksums --block-existence --container-state o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}/${TESTFILE} --output-dir ${TEMP_DIR}
     ${json} =      Evaluate  json.loads('''${output}''')      json
 
     # 'keys' array should be empty if all keys and their replicas passed checksum verification

--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageSize;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -67,6 +68,7 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.util.ShutdownHookManager;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.VersionInfo;
@@ -190,6 +192,12 @@ public final class RandomKeyGenerator implements Callable<Void>, FreonSubcommand
           "volumes, buckets and keys."
   )
   private boolean cleanObjects = false;
+
+  @Option(
+      names = "--bucket-layout",
+      description = "Specifies the bucket layout (e.g., FILE_SYSTEM_OPTIMIZED, OBJECT_STORE, LEGACY)."
+  )
+  private BucketLayout bucketLayout;
 
   private ReplicationConfig replicationConfig;
 
@@ -647,6 +655,16 @@ public final class RandomKeyGenerator implements Callable<Void>, FreonSubcommand
   }
 
   /**
+   * Returns the current size of the buckets map.
+   *
+   * @return number of buckets created and added to the map
+   */
+  @VisibleForTesting
+  int getBucketMapSize() {
+    return buckets.size();
+  }
+
+  /**
    * Wrapper to hold ozone keyValidate entry.
    */
   private static class KeyValidate {
@@ -757,7 +775,14 @@ public final class RandomKeyGenerator implements Callable<Void>, FreonSubcommand
         .createActivatedSpan("createBucket")) {
 
       long start = System.nanoTime();
-      volume.createBucket(bucketName);
+      if (bucketLayout != null) {
+        BucketArgs bucketArgs = BucketArgs.newBuilder()
+            .setBucketLayout(bucketLayout)
+            .build();
+        volume.createBucket(bucketName, bucketArgs);
+      } else {
+        volume.createBucket(bucketName);
+      }
       long bucketCreationDuration = System.nanoTime() - start;
       histograms.get(FreonOps.BUCKET_CREATE.ordinal())
           .update(bucketCreationDuration);
@@ -880,7 +905,8 @@ public final class RandomKeyGenerator implements Callable<Void>, FreonSubcommand
     return waitUntilAddedToMap(volumes, volumeNumber);
   }
 
-  private OzoneBucket getBucket(Integer bucketNumber) {
+  @VisibleForTesting
+  OzoneBucket getBucket(Integer bucketNumber) {
     return waitUntilAddedToMap(buckets, bucketNumber);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -111,7 +111,6 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OmConfig;
 import org.apache.hadoop.ozone.om.OzonePrefixPathImpl;
-import org.apache.hadoop.ozone.om.TrashPolicyOzone;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
@@ -1685,7 +1684,7 @@ abstract class AbstractOzoneFileSystemTest {
     ContractTestUtils.touch(fs, path);
     assertTrue(trash.getConf().getClass(
         "fs.trash.classname", TrashPolicy.class).
-        isAssignableFrom(TrashPolicyOzone.class));
+        isAssignableFrom(OzoneTrashPolicy.class));
     assertEquals(TRASH_INTERVAL, trash.getConf().
         getFloat(OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY, 0), 0);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -117,7 +117,6 @@ import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OmConfig;
-import org.apache.hadoop.ozone.om.TrashPolicyOzone;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
@@ -1869,7 +1868,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
     assertTrue(trash.getConf().getClass(
         "fs.trash.classname", TrashPolicy.class).
-        isAssignableFrom(TrashPolicyOzone.class));
+        isAssignableFrom(OzoneTrashPolicy.class));
 
     long prevNumTrashDeletes = getOMMetrics().getNumTrashDeletes();
     long prevNumTrashFileDeletes = getOMMetrics().getNumTrashFilesDeletes();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
@@ -79,6 +79,8 @@ import org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.service.DirectoryDeletingService;
 import org.apache.hadoop.ozone.om.service.KeyDeletingService;
+import org.apache.hadoop.ozone.om.snapshot.filter.ReclaimableDirFilter;
+import org.apache.hadoop.ozone.om.snapshot.filter.ReclaimableKeyFilter;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
@@ -592,8 +594,7 @@ public class TestDirectoryDeletingServiceWithFSO {
     OmSnapshotManager omSnapshotManager = Mockito.spy(ozoneManager.getOmSnapshotManager());
     when(ozoneManager.getOmSnapshotManager()).thenAnswer(i -> omSnapshotManager);
     DirectoryDeletingService service = Mockito.spy(new DirectoryDeletingService(1000, TimeUnit.MILLISECONDS, 1000,
-        ozoneManager,
-        cluster.getConf(), 1));
+        ozoneManager, cluster.getConf(), 1, false));
     service.shutdown();
     final int initialSnapshotCount =
         (int) cluster.getOzoneManager().getMetadataManager().countRowsInTable(snapshotInfoTable);
@@ -627,7 +628,8 @@ public class TestDirectoryDeletingServiceWithFSO {
       }
       return null;
     }).when(service).optimizeDirDeletesAndSubmitRequest(anyLong(), anyLong(),
-        anyLong(), anyList(), anyList(), eq(null), anyLong(), anyLong(), Mockito.any(), any(),
+        anyLong(), anyList(), anyList(), eq(null), anyLong(), anyLong(), any(),
+        any(ReclaimableDirFilter.class), any(ReclaimableKeyFilter.class), any(),
         anyLong());
 
     Mockito.doAnswer(i -> {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
@@ -277,8 +277,6 @@ public class TestDirectoryDeletingServiceWithFSO {
     assertEquals(18, metrics.getNumSubDirsMovedToDeletedDirTable());
     assertEquals(18, metrics.getNumSubDirsSentForPurge());
 
-
-    long elapsedRunCount = dirDeletingService.getRunCount().get() - preRunCount;
     assertThat(dirDeletingService.getRunCount().get()).isGreaterThan(1);
     // Ensure dir deleting speed, here provide a backup value for safe CI
     GenericTestUtils.waitFor(() -> dirDeletingService.getRunCount().get() - preRunCount >= 7, 1000, 100000);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerBalancerOperations.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerBalancerOperations.java
@@ -82,7 +82,7 @@ public class TestContainerBalancerOperations {
     Optional<Long> maxSizeLeavingSourceInGB = Optional.of(6L);
     Optional<Integer> balancingInterval = Optional.of(70);
     Optional<Integer> moveTimeout = Optional.of(65);
-    Optional<Integer> moveReplicationTimeout = Optional.of(55);
+    Optional<Integer> moveReplicationTimeout = Optional.of(50);
     Optional<Boolean> networkTopologyEnable = Optional.of(false);
     Optional<String> includeNodes = Optional.of("");
     Optional<String> excludeNodes = Optional.of("");
@@ -147,7 +147,7 @@ public class TestContainerBalancerOperations {
     Optional<Long> maxSizeEnteringTargetInGB = Optional.of(6L);
     Optional<Long> maxSizeLeavingSourceInGB = Optional.of(6L);
     Optional<Integer> moveTimeout = Optional.of(65);
-    Optional<Integer> moveReplicationTimeout = Optional.of(55);
+    Optional<Integer> moveReplicationTimeout = Optional.of(50);
     Optional<Boolean> networkTopologyEnable = Optional.of(true);
     Optional<String> includeNodes = Optional.of("");
     Optional<String> excludeNodes = Optional.of("");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
@@ -21,6 +21,8 @@ import static org.apache.ozone.test.GenericTestUtils.waitFor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
@@ -184,5 +186,26 @@ public abstract class TestRandomKeyGenerator implements NonHATests.TestCase {
     assertEquals(12, randomKeyGenerator.getNumberOfKeysAdded());
     assertEquals(2, randomKeyGenerator.getNumberOfVolumesCleaned());
     assertEquals(6, randomKeyGenerator.getNumberOfBucketsCleaned());
+  }
+
+  @Test
+  void testBucketLayoutOption() {
+    RandomKeyGenerator randomKeyGenerator =
+        new RandomKeyGenerator(cluster().getConf());
+    CommandLine cmd = new CommandLine(randomKeyGenerator);
+    cmd.execute("--num-of-volumes", "1",
+        "--num-of-buckets", "1",
+        "--num-of-keys", "2",
+        "--bucket-layout", "OBJECT_STORE"
+    );
+
+    assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
+    assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
+    assertEquals(2, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(1, randomKeyGenerator.getBucketMapSize());
+
+    // Fetch the bucket and check its layout
+    OzoneBucket bucket = randomKeyGenerator.getBucket(0);
+    assertEquals(BucketLayout.OBJECT_STORE, bucket.getBucketLayout());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDirectoryCleaningService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDirectoryCleaningService.java
@@ -49,7 +49,7 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
-import org.apache.hadoop.ozone.om.service.SnapshotDirectoryCleaningService;
+import org.apache.hadoop.ozone.om.service.DirectoryDeletingService;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterAll;
@@ -76,7 +76,7 @@ public class TestSnapshotDirectoryCleaningService {
   @BeforeAll
   public static void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
-    conf.setInt(OMConfigKeys.OZONE_SNAPSHOT_DIRECTORY_SERVICE_INTERVAL, 2500);
+    conf.setInt(OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL, 2500);
     conf.setBoolean(OZONE_SNAPSHOT_DEEP_CLEANING_ENABLED, true);
     conf.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 2500,
         TimeUnit.MILLISECONDS);
@@ -140,8 +140,8 @@ public class TestSnapshotDirectoryCleaningService {
         cluster.getOzoneManager().getMetadataManager().getDeletedTable();
     Table<String, SnapshotInfo> snapshotInfoTable =
         cluster.getOzoneManager().getMetadataManager().getSnapshotInfoTable();
-    SnapshotDirectoryCleaningService snapshotDirectoryCleaningService =
-        cluster.getOzoneManager().getKeyManager().getSnapshotDirectoryService();
+    DirectoryDeletingService snapshotDirectoryCleaningService =
+        cluster.getOzoneManager().getKeyManager().getDirDeletingService();
 
     /*    DirTable
     /v/b/snapDir

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDirectoryCleaningService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDirectoryCleaningService.java
@@ -24,7 +24,6 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_DEEP_CLEANI
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDirectoryCleaningService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDirectoryCleaningService.java
@@ -140,7 +140,7 @@ public class TestSnapshotDirectoryCleaningService {
         cluster.getOzoneManager().getMetadataManager().getDeletedTable();
     Table<String, SnapshotInfo> snapshotInfoTable =
         cluster.getOzoneManager().getMetadataManager().getSnapshotInfoTable();
-    DirectoryDeletingService snapshotDirectoryCleaningService =
+    DirectoryDeletingService directoryDeletingService =
         cluster.getOzoneManager().getKeyManager().getDirDeletingService();
 
     /*    DirTable
@@ -220,8 +220,8 @@ public class TestSnapshotDirectoryCleaningService {
     fs.delete(root, true);
     assertTableRowCount(deletedKeyTable, 10);
     client.getObjectStore().createSnapshot(volumeName, bucketName, "snap3");
-    long prevRunCount = snapshotDirectoryCleaningService.getRunCount().get();
-    GenericTestUtils.waitFor(() -> snapshotDirectoryCleaningService.getRunCount().get()
+    long prevRunCount = directoryDeletingService.getRunCount().get();
+    GenericTestUtils.waitFor(() -> directoryDeletingService.getRunCount().get()
         > prevRunCount + 1, 100, 10000);
 
     Thread.sleep(2000);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
@@ -103,7 +103,8 @@ public abstract class TestOzoneDebugShell implements NonHATests.TestCase {
     String[] args = new String[] {
         getSetConfStringFromConf(OMConfigKeys.OZONE_OM_ADDRESS_KEY),
         getSetConfStringFromConf(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY),
-        "replicas", "verify", "--checksums", "--block-existence", fullKeyPath, "--output-dir", "/"//, "--all-results"
+        "replicas", "verify", "--checksums", "--block-existence", "--container-state", fullKeyPath,
+        "--output-dir", "/"//, "--all-results"
     };
 
     int exitCode = ozoneDebugShell.execute(args);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -69,6 +69,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.TrashPolicy;
 import org.apache.hadoop.fs.ozone.OzoneFsShell;
+import org.apache.hadoop.fs.ozone.OzoneTrashPolicy;
 import org.apache.hadoop.hdds.JsonTestUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.client.ReplicationType;
@@ -92,7 +93,6 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManager;
-import org.apache.hadoop.ozone.om.TrashPolicyOzone;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
@@ -991,17 +991,17 @@ public class TestOzoneShellHA {
 
   /**
    * Helper function to retrieve Ozone client configuration for ozone
-   * trash testing with TrashPolicyOzone.
+   * trash testing with OzoneTrashPolicy.
    * @param hostPrefix Scheme + Authority. e.g. ofs://om-service-test1
    * @param configuration Server config to generate client config from.
    * @return Config ofs configuration added with fs.trash.classname
-   * = TrashPolicyOzone.
+   * = OzoneTrashPolicy.
    */
   private OzoneConfiguration getClientConfForOzoneTrashPolicy(
           String hostPrefix, OzoneConfiguration configuration) {
     OzoneConfiguration clientConf =
             getClientConfForOFS(hostPrefix, configuration);
-    clientConf.setClass("fs.trash.classname", TrashPolicyOzone.class,
+    clientConf.setClass("fs.trash.classname", OzoneTrashPolicy.class,
             TrashPolicy.class);
     return clientConf;
   }
@@ -1186,7 +1186,7 @@ public class TestOzoneShellHA {
 
     // Test delete from Trash directory removes item from filesystem
 
-    // setup configuration to use TrashPolicyOzone
+    // setup configuration to use OzoneTrashPolicy
     // (default is TrashPolicyDefault)
     final String hostPrefix = OZONE_OFS_URI_SCHEME + "://" + omServiceId;
     OzoneConfiguration clientConf =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.ozone.om.service.CompactionService;
 import org.apache.hadoop.ozone.om.service.DirectoryDeletingService;
 import org.apache.hadoop.ozone.om.service.KeyDeletingService;
 import org.apache.hadoop.ozone.om.service.SnapshotDeletingService;
-import org.apache.hadoop.ozone.om.service.SnapshotDirectoryCleaningService;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExpiredMultipartUploadsBucket;
 import org.apache.ratis.util.function.CheckedFunction;
 
@@ -274,7 +273,14 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
   void refresh(OmKeyInfo key) throws IOException;
 
   /**
-   * Returns an iterator for pending deleted directories.
+   * Returns an iterator for pending deleted directories all buckets.
+   */
+  default TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>> getDeletedDirEntries() throws IOException {
+    return getDeletedDirEntries(null, null);
+  }
+
+  /**
+   * Returns an iterator for pending deleted directories for volume and bucket.
    * @throws IOException
    */
   TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>> getDeletedDirEntries(
@@ -301,7 +307,8 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    * @throws IOException
    */
   DeleteKeysResult getPendingDeletionSubDirs(long volumeId, long bucketId,
-      OmKeyInfo parentInfo, long remainingBufLimit) throws IOException;
+      OmKeyInfo parentInfo, CheckedFunction<Table.KeyValue<String, OmKeyInfo>, Boolean, IOException> filter,
+      long remainingBufLimit) throws IOException;
 
   /**
    * Returns all sub files under the given parent directory.
@@ -311,7 +318,8 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    * @throws IOException
    */
   DeleteKeysResult getPendingDeletionSubFiles(long volumeId,
-      long bucketId, OmKeyInfo parentInfo, long remainingBufLimit)
+      long bucketId, OmKeyInfo parentInfo,
+      CheckedFunction<Table.KeyValue<String, OmKeyInfo>, Boolean, IOException> filter, long remainingBufLimit)
           throws IOException;
 
   /**
@@ -343,12 +351,6 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    * @return Background service.
    */
   SnapshotDeletingService getSnapshotDeletingService();
-
-  /**
-   * Returns the instance of Snapshot Directory service.
-   * @return Background service.
-   */
-  SnapshotDirectoryCleaningService getSnapshotDirectoryService();
 
   /**
    * Returns the instance of CompactionService.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -131,6 +131,7 @@ import org.apache.hadoop.hdds.security.token.OzoneBlockTokenSecretManager;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -160,6 +161,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.WithParentObjectId;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.OMMultipartUploadUtils;
@@ -734,7 +736,7 @@ public class KeyManagerImpl implements KeyManager {
 
   @Override
   public PendingKeysDeletion getPendingDeletionKeys(
-      final CheckedFunction<Table.KeyValue<String, OmKeyInfo>, Boolean, IOException> filter, final int count)
+      final CheckedFunction<KeyValue<String, OmKeyInfo>, Boolean, IOException> filter, final int count)
       throws IOException {
     return getPendingDeletionKeys(null, null, null, filter, count);
   }
@@ -742,13 +744,13 @@ public class KeyManagerImpl implements KeyManager {
   @Override
   public PendingKeysDeletion getPendingDeletionKeys(
       String volume, String bucket, String startKey,
-      CheckedFunction<Table.KeyValue<String, OmKeyInfo>, Boolean, IOException> filter,
+      CheckedFunction<KeyValue<String, OmKeyInfo>, Boolean, IOException> filter,
       int count) throws IOException {
     List<BlockGroup> keyBlocksList = Lists.newArrayList();
     Map<String, RepeatedOmKeyInfo> keysToModify = new HashMap<>();
     // Bucket prefix would be empty if volume is empty i.e. either null or "".
     Optional<String> bucketPrefix = getBucketPrefix(volume, bucket, false);
-    try (TableIterator<String, ? extends Table.KeyValue<String, RepeatedOmKeyInfo>>
+    try (TableIterator<String, ? extends KeyValue<String, RepeatedOmKeyInfo>>
              delKeyIter = metadataManager.getDeletedTable().iterator(bucketPrefix.orElse(""))) {
 
       /* Seeking to the start key if it not null. The next key picked up would be ensured to start with the bucket
@@ -760,7 +762,7 @@ public class KeyManagerImpl implements KeyManager {
       int currentCount = 0;
       while (delKeyIter.hasNext() && currentCount < count) {
         RepeatedOmKeyInfo notReclaimableKeyInfo = new RepeatedOmKeyInfo();
-        Table.KeyValue<String, RepeatedOmKeyInfo> kv = delKeyIter.next();
+        KeyValue<String, RepeatedOmKeyInfo> kv = delKeyIter.next();
         if (kv != null) {
           List<BlockGroup> blockGroupList = Lists.newArrayList();
           // Multiple keys with the same path can be queued in one DB entry
@@ -795,12 +797,12 @@ public class KeyManagerImpl implements KeyManager {
     return new PendingKeysDeletion(keyBlocksList, keysToModify);
   }
 
-  private <V, R> List<Table.KeyValue<String, R>> getTableEntries(String startKey,
-          TableIterator<String, ? extends Table.KeyValue<String, V>> tableIterator,
+  private <V, R> List<KeyValue<String, R>> getTableEntries(String startKey,
+          TableIterator<String, ? extends KeyValue<String, V>> tableIterator,
           Function<V, R> valueFunction,
-          CheckedFunction<Table.KeyValue<String, V>, Boolean, IOException> filter,
+          CheckedFunction<KeyValue<String, V>, Boolean, IOException> filter,
           int size) throws IOException {
-    List<Table.KeyValue<String, R>> entries = new ArrayList<>();
+    List<KeyValue<String, R>> entries = new ArrayList<>();
     /* Seek to the start key if it's not null. The next key in queue is ensured to start with the bucket
          prefix, {@link org.apache.hadoop.hdds.utils.db.Table#iterator(bucketPrefix)} would ensure this.
     */
@@ -811,7 +813,7 @@ public class KeyManagerImpl implements KeyManager {
     }
     int currentCount = 0;
     while (tableIterator.hasNext() && currentCount < size) {
-      Table.KeyValue<String, V> kv = tableIterator.next();
+      KeyValue<String, V> kv = tableIterator.next();
       if (kv != null && filter.apply(kv)) {
         entries.add(Table.newKeyValue(kv.getKey(), valueFunction.apply(kv.getValue())));
         currentCount++;
@@ -833,11 +835,11 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
-  public List<Table.KeyValue<String, String>> getRenamesKeyEntries(
+  public List<KeyValue<String, String>> getRenamesKeyEntries(
       String volume, String bucket, String startKey,
-      CheckedFunction<Table.KeyValue<String, String>, Boolean, IOException> filter, int size) throws IOException {
+      CheckedFunction<KeyValue<String, String>, Boolean, IOException> filter, int size) throws IOException {
     Optional<String> bucketPrefix = getBucketPrefix(volume, bucket, false);
-    try (TableIterator<String, ? extends Table.KeyValue<String, String>>
+    try (TableIterator<String, ? extends KeyValue<String, String>>
              renamedKeyIter = metadataManager.getSnapshotRenamedTable().iterator(bucketPrefix.orElse(""))) {
       return getTableEntries(startKey, renamedKeyIter, Function.identity(), filter, size);
     }
@@ -882,12 +884,12 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
-  public List<Table.KeyValue<String, List<OmKeyInfo>>> getDeletedKeyEntries(
+  public List<KeyValue<String, List<OmKeyInfo>>> getDeletedKeyEntries(
       String volume, String bucket, String startKey,
-      CheckedFunction<Table.KeyValue<String, RepeatedOmKeyInfo>, Boolean, IOException> filter,
+      CheckedFunction<KeyValue<String, RepeatedOmKeyInfo>, Boolean, IOException> filter,
       int size) throws IOException {
     Optional<String> bucketPrefix = getBucketPrefix(volume, bucket, false);
-    try (TableIterator<String, ? extends Table.KeyValue<String, RepeatedOmKeyInfo>>
+    try (TableIterator<String, ? extends KeyValue<String, RepeatedOmKeyInfo>>
              delKeyIter = metadataManager.getDeletedTable().iterator(bucketPrefix.orElse(""))) {
       return getTableEntries(startKey, delKeyIter, RepeatedOmKeyInfo::cloneOmKeyInfoList, filter, size);
     }
@@ -1537,10 +1539,10 @@ public class KeyManagerImpl implements KeyManager {
       }
     }
 
-    try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
+    try (TableIterator<String, ? extends KeyValue<String, OmKeyInfo>>
         keyTblItr = keyTable.iterator(targetKey)) {
       while (keyTblItr.hasNext()) {
-        Table.KeyValue<String, OmKeyInfo> keyValue = keyTblItr.next();
+        KeyValue<String, OmKeyInfo> keyValue = keyTblItr.next();
         if (keyValue != null) {
           String key = keyValue.getKey();
           // HDDS-7871: RocksIterator#seek() may position at the key
@@ -1851,7 +1853,7 @@ public class KeyManagerImpl implements KeyManager {
     String keyArgs = OzoneFSUtils.addTrailingSlashIfNeeded(
         metadataManager.getOzoneKey(volumeName, bucketName, keyName));
 
-    TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>> iterator;
+    TableIterator<String, ? extends KeyValue<String, OmKeyInfo>> iterator;
     Table<String, OmKeyInfo> keyTable;
     metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
         bucketName);
@@ -1908,12 +1910,12 @@ public class KeyManagerImpl implements KeyManager {
     return fileStatusList;
   }
 
-  private TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
+  private TableIterator<String, ? extends KeyValue<String, OmKeyInfo>>
       getIteratorForKeyInTableCache(
       boolean recursive, String startKey, String volumeName, String bucketName,
       TreeMap<String, OzoneFileStatus> cacheKeyMap, String keyArgs,
       Table<String, OmKeyInfo> keyTable) throws IOException {
-    TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>> iterator;
+    TableIterator<String, ? extends KeyValue<String, OmKeyInfo>> iterator;
     Iterator<Map.Entry<CacheKey<String>, CacheValue<OmKeyInfo>>>
         cacheIter = keyTable.cacheIterator();
     String startCacheKey = metadataManager.getOzoneKey(volumeName, bucketName, startKey);
@@ -1931,12 +1933,12 @@ public class KeyManagerImpl implements KeyManager {
       TreeMap<String, OzoneFileStatus> cacheKeyMap, String keyArgs,
       Table<String, OmKeyInfo> keyTable,
       TableIterator<String,
-          ? extends Table.KeyValue<String, OmKeyInfo>> iterator)
+          ? extends KeyValue<String, OmKeyInfo>> iterator)
       throws IOException {
     // Then, find key in DB
     String seekKeyInDb =
         metadataManager.getOzoneKey(volumeName, bucketName, startKey);
-    Table.KeyValue<String, OmKeyInfo> entry = iterator.seek(seekKeyInDb);
+    KeyValue<String, OmKeyInfo> entry = iterator.seek(seekKeyInDb);
     int countEntries = 0;
     if (iterator.hasNext()) {
       if (entry.getKey().equals(keyArgs)) {
@@ -2187,7 +2189,7 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
-  public TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>> getDeletedDirEntries(
+  public TableIterator<String, ? extends KeyValue<String, OmKeyInfo>> getDeletedDirEntries(
       String volume, String bucket) throws IOException {
     Optional<String> bucketPrefix = getBucketPrefix(volume, bucket, true);
     return metadataManager.getDeletedDirTable().iterator(bucketPrefix.orElse(""));
@@ -2196,101 +2198,52 @@ public class KeyManagerImpl implements KeyManager {
   @Override
   public DeleteKeysResult getPendingDeletionSubDirs(long volumeId, long bucketId,
       OmKeyInfo parentInfo, long remainingBufLimit) throws IOException {
-    String seekDirInDB = metadataManager.getOzonePathKey(volumeId, bucketId,
-        parentInfo.getObjectID(), "");
-    long countEntries = 0;
-
-    Table<String, OmDirectoryInfo> dirTable = metadataManager.getDirectoryTable();
-    try (TableIterator<String,
-        ? extends Table.KeyValue<String, OmDirectoryInfo>>
-        iterator = dirTable.iterator(seekDirInDB)) {
-      return gatherSubDirsWithIterator(parentInfo, countEntries, iterator, remainingBufLimit);
-    }
-
+    return gatherSubPathsWithIterator(volumeId, bucketId, parentInfo, metadataManager.getDirectoryTable(),
+        omDirectoryInfo -> OMFileRequest.getKeyInfoWithFullPath(parentInfo, omDirectoryInfo), remainingBufLimit);
   }
 
-  private DeleteKeysResult gatherSubDirsWithIterator(OmKeyInfo parentInfo,
-      long countEntries,
-      TableIterator<String,
-          ? extends Table.KeyValue<String, OmDirectoryInfo>> iterator, long remainingBufLimit)
-      throws IOException {
-    List<OmKeyInfo> directories = new ArrayList<>();
+  private <T extends WithParentObjectId> DeleteKeysResult gatherSubPathsWithIterator(
+      long volumeId, long bucketId, OmKeyInfo parentInfo,
+      Table<String, T> table, Function<T, OmKeyInfo> deleteKeyTransformer,
+      long remainingBufLimit) throws IOException {
+    List<OmKeyInfo> keyInfos = new ArrayList<>();
+    String seekFileInDB = metadataManager.getOzonePathKey(volumeId, bucketId,
+        parentInfo.getObjectID(), "");
     long consumedSize = 0;
-    boolean processedSubDirs = false;
-
-    while (iterator.hasNext() && remainingBufLimit > 0) {
-      Table.KeyValue<String, OmDirectoryInfo> entry = iterator.next();
-      OmDirectoryInfo dirInfo = entry.getValue();
-      long objectSerializedSize = entry.getRawSize();
-      if (!OMFileRequest.isImmediateChild(dirInfo.getParentObjectID(),
-          parentInfo.getObjectID())) {
-        processedSubDirs = true;
-        break;
+    boolean processedSubPaths = false;
+    try (TableIterator<String, ? extends KeyValue<String, T>> iterator = table.iterator(seekFileInDB)) {
+      while (iterator.hasNext() && remainingBufLimit > 0) {
+        KeyValue<String, T> entry = iterator.next();
+        T withParentObjectId = entry.getValue();
+        long objectSerializedSize = entry.getRawSize();
+        if (!OMFileRequest.isImmediateChild(withParentObjectId.getParentObjectID(),
+            parentInfo.getObjectID())) {
+          processedSubPaths = true;
+          break;
+        }
+        if (!table.isExist(entry.getKey())) {
+          continue;
+        }
+        if (remainingBufLimit - objectSerializedSize < 0) {
+          break;
+        }
+        OmKeyInfo keyInfo = deleteKeyTransformer.apply(withParentObjectId);
+        keyInfos.add(keyInfo);
+        remainingBufLimit -= objectSerializedSize;
+        consumedSize += objectSerializedSize;
       }
-      if (!metadataManager.getDirectoryTable().isExist(entry.getKey())) {
-        continue;
-      }
-      if (remainingBufLimit - objectSerializedSize < 0) {
-        break;
-      }
-      String dirName = OMFileRequest.getAbsolutePath(parentInfo.getKeyName(),
-          dirInfo.getName());
-      OmKeyInfo omKeyInfo = OMFileRequest.getOmKeyInfo(
-          parentInfo.getVolumeName(), parentInfo.getBucketName(), dirInfo,
-          dirName);
-      directories.add(omKeyInfo);
-      countEntries++;
-      remainingBufLimit -= objectSerializedSize;
-      consumedSize += objectSerializedSize;
+      processedSubPaths = processedSubPaths || (!iterator.hasNext());
+      return new DeleteKeysResult(keyInfos, consumedSize, processedSubPaths);
     }
-
-    processedSubDirs = processedSubDirs || (!iterator.hasNext());
-
-    return new DeleteKeysResult(directories, consumedSize, processedSubDirs);
   }
 
   @Override
   public DeleteKeysResult getPendingDeletionSubFiles(long volumeId,
       long bucketId, OmKeyInfo parentInfo, long remainingBufLimit)
           throws IOException {
-    List<OmKeyInfo> files = new ArrayList<>();
-    String seekFileInDB = metadataManager.getOzonePathKey(volumeId, bucketId,
-        parentInfo.getObjectID(), "");
-    long consumedSize = 0;
-    boolean processedSubFiles = false;
-
-    Table fileTable = metadataManager.getFileTable();
-    try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
-        iterator = fileTable.iterator(seekFileInDB)) {
-
-      while (iterator.hasNext() && remainingBufLimit > 0) {
-        Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
-        OmKeyInfo fileInfo = entry.getValue();
-        long objectSerializedSize = entry.getRawSize();
-        if (!OMFileRequest.isImmediateChild(fileInfo.getParentObjectID(),
-            parentInfo.getObjectID())) {
-          processedSubFiles = true;
-          break;
-        }
-        if (!metadataManager.getFileTable().isExist(entry.getKey())) {
-          continue;
-        }
-        if (remainingBufLimit - objectSerializedSize < 0) {
-          break;
-        }
-        fileInfo.setFileName(fileInfo.getKeyName());
-        String fullKeyPath = OMFileRequest.getAbsolutePath(
-            parentInfo.getKeyName(), fileInfo.getKeyName());
-        fileInfo.setKeyName(fullKeyPath);
-
-        files.add(fileInfo);
-        remainingBufLimit -= objectSerializedSize;
-        consumedSize += objectSerializedSize;
-      }
-      processedSubFiles = processedSubFiles || (!iterator.hasNext());
-    }
-
-    return new DeleteKeysResult(files, consumedSize, processedSubFiles);
+    return gatherSubPathsWithIterator(volumeId, bucketId, parentInfo, metadataManager.getFileTable(),
+        keyInfo -> OMFileRequest.getKeyInfoWithFullPath(parentInfo, keyInfo),
+        remainingBufLimit);
   }
 
   public boolean isBucketFSOptimized(String volName, String buckName)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -131,6 +131,7 @@ import org.apache.hadoop.hdds.security.token.OzoneBlockTokenSecretManager;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -735,7 +736,7 @@ public class KeyManagerImpl implements KeyManager {
 
   @Override
   public PendingKeysDeletion getPendingDeletionKeys(
-      final CheckedFunction<Table.KeyValue<String, OmKeyInfo>, Boolean, IOException> filter, final int count)
+      final CheckedFunction<KeyValue<String, OmKeyInfo>, Boolean, IOException> filter, final int count)
       throws IOException {
     return getPendingDeletionKeys(null, null, null, filter, count);
   }
@@ -743,13 +744,13 @@ public class KeyManagerImpl implements KeyManager {
   @Override
   public PendingKeysDeletion getPendingDeletionKeys(
       String volume, String bucket, String startKey,
-      CheckedFunction<Table.KeyValue<String, OmKeyInfo>, Boolean, IOException> filter,
+      CheckedFunction<KeyValue<String, OmKeyInfo>, Boolean, IOException> filter,
       int count) throws IOException {
     List<BlockGroup> keyBlocksList = Lists.newArrayList();
     Map<String, RepeatedOmKeyInfo> keysToModify = new HashMap<>();
     // Bucket prefix would be empty if volume is empty i.e. either null or "".
     Optional<String> bucketPrefix = getBucketPrefix(volume, bucket, false);
-    try (TableIterator<String, ? extends Table.KeyValue<String, RepeatedOmKeyInfo>>
+    try (TableIterator<String, ? extends KeyValue<String, RepeatedOmKeyInfo>>
              delKeyIter = metadataManager.getDeletedTable().iterator(bucketPrefix.orElse(""))) {
 
       /* Seeking to the start key if it not null. The next key picked up would be ensured to start with the bucket
@@ -761,7 +762,7 @@ public class KeyManagerImpl implements KeyManager {
       int currentCount = 0;
       while (delKeyIter.hasNext() && currentCount < count) {
         RepeatedOmKeyInfo notReclaimableKeyInfo = new RepeatedOmKeyInfo();
-        Table.KeyValue<String, RepeatedOmKeyInfo> kv = delKeyIter.next();
+        KeyValue<String, RepeatedOmKeyInfo> kv = delKeyIter.next();
         if (kv != null) {
           List<BlockGroup> blockGroupList = Lists.newArrayList();
           // Multiple keys with the same path can be queued in one DB entry
@@ -796,12 +797,12 @@ public class KeyManagerImpl implements KeyManager {
     return new PendingKeysDeletion(keyBlocksList, keysToModify);
   }
 
-  private <V, R> List<Table.KeyValue<String, R>> getTableEntries(String startKey,
-          TableIterator<String, ? extends Table.KeyValue<String, V>> tableIterator,
+  private <V, R> List<KeyValue<String, R>> getTableEntries(String startKey,
+          TableIterator<String, ? extends KeyValue<String, V>> tableIterator,
           Function<V, R> valueFunction,
-          CheckedFunction<Table.KeyValue<String, V>, Boolean, IOException> filter,
+          CheckedFunction<KeyValue<String, V>, Boolean, IOException> filter,
           int size) throws IOException {
-    List<Table.KeyValue<String, R>> entries = new ArrayList<>();
+    List<KeyValue<String, R>> entries = new ArrayList<>();
     /* Seek to the start key if it's not null. The next key in queue is ensured to start with the bucket
          prefix, {@link org.apache.hadoop.hdds.utils.db.Table#iterator(bucketPrefix)} would ensure this.
     */
@@ -812,7 +813,7 @@ public class KeyManagerImpl implements KeyManager {
     }
     int currentCount = 0;
     while (tableIterator.hasNext() && currentCount < size) {
-      Table.KeyValue<String, V> kv = tableIterator.next();
+      KeyValue<String, V> kv = tableIterator.next();
       if (kv != null && filter.apply(kv)) {
         entries.add(Table.newKeyValue(kv.getKey(), valueFunction.apply(kv.getValue())));
         currentCount++;
@@ -834,11 +835,11 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
-  public List<Table.KeyValue<String, String>> getRenamesKeyEntries(
+  public List<KeyValue<String, String>> getRenamesKeyEntries(
       String volume, String bucket, String startKey,
-      CheckedFunction<Table.KeyValue<String, String>, Boolean, IOException> filter, int size) throws IOException {
+      CheckedFunction<KeyValue<String, String>, Boolean, IOException> filter, int size) throws IOException {
     Optional<String> bucketPrefix = getBucketPrefix(volume, bucket, false);
-    try (TableIterator<String, ? extends Table.KeyValue<String, String>>
+    try (TableIterator<String, ? extends KeyValue<String, String>>
              renamedKeyIter = metadataManager.getSnapshotRenamedTable().iterator(bucketPrefix.orElse(""))) {
       return getTableEntries(startKey, renamedKeyIter, Function.identity(), filter, size);
     }
@@ -883,12 +884,12 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
-  public List<Table.KeyValue<String, List<OmKeyInfo>>> getDeletedKeyEntries(
+  public List<KeyValue<String, List<OmKeyInfo>>> getDeletedKeyEntries(
       String volume, String bucket, String startKey,
-      CheckedFunction<Table.KeyValue<String, RepeatedOmKeyInfo>, Boolean, IOException> filter,
+      CheckedFunction<KeyValue<String, RepeatedOmKeyInfo>, Boolean, IOException> filter,
       int size) throws IOException {
     Optional<String> bucketPrefix = getBucketPrefix(volume, bucket, false);
-    try (TableIterator<String, ? extends Table.KeyValue<String, RepeatedOmKeyInfo>>
+    try (TableIterator<String, ? extends KeyValue<String, RepeatedOmKeyInfo>>
              delKeyIter = metadataManager.getDeletedTable().iterator(bucketPrefix.orElse(""))) {
       return getTableEntries(startKey, delKeyIter, RepeatedOmKeyInfo::cloneOmKeyInfoList, filter, size);
     }
@@ -1538,10 +1539,10 @@ public class KeyManagerImpl implements KeyManager {
       }
     }
 
-    try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
+    try (TableIterator<String, ? extends KeyValue<String, OmKeyInfo>>
         keyTblItr = keyTable.iterator(targetKey)) {
       while (keyTblItr.hasNext()) {
-        Table.KeyValue<String, OmKeyInfo> keyValue = keyTblItr.next();
+        KeyValue<String, OmKeyInfo> keyValue = keyTblItr.next();
         if (keyValue != null) {
           String key = keyValue.getKey();
           // HDDS-7871: RocksIterator#seek() may position at the key
@@ -1852,7 +1853,7 @@ public class KeyManagerImpl implements KeyManager {
     String keyArgs = OzoneFSUtils.addTrailingSlashIfNeeded(
         metadataManager.getOzoneKey(volumeName, bucketName, keyName));
 
-    TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>> iterator;
+    TableIterator<String, ? extends KeyValue<String, OmKeyInfo>> iterator;
     Table<String, OmKeyInfo> keyTable;
     metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
         bucketName);
@@ -1909,12 +1910,12 @@ public class KeyManagerImpl implements KeyManager {
     return fileStatusList;
   }
 
-  private TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
+  private TableIterator<String, ? extends KeyValue<String, OmKeyInfo>>
       getIteratorForKeyInTableCache(
       boolean recursive, String startKey, String volumeName, String bucketName,
       TreeMap<String, OzoneFileStatus> cacheKeyMap, String keyArgs,
       Table<String, OmKeyInfo> keyTable) throws IOException {
-    TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>> iterator;
+    TableIterator<String, ? extends KeyValue<String, OmKeyInfo>> iterator;
     Iterator<Map.Entry<CacheKey<String>, CacheValue<OmKeyInfo>>>
         cacheIter = keyTable.cacheIterator();
     String startCacheKey = metadataManager.getOzoneKey(volumeName, bucketName, startKey);
@@ -1932,12 +1933,12 @@ public class KeyManagerImpl implements KeyManager {
       TreeMap<String, OzoneFileStatus> cacheKeyMap, String keyArgs,
       Table<String, OmKeyInfo> keyTable,
       TableIterator<String,
-          ? extends Table.KeyValue<String, OmKeyInfo>> iterator)
+          ? extends KeyValue<String, OmKeyInfo>> iterator)
       throws IOException {
     // Then, find key in DB
     String seekKeyInDb =
         metadataManager.getOzoneKey(volumeName, bucketName, startKey);
-    Table.KeyValue<String, OmKeyInfo> entry = iterator.seek(seekKeyInDb);
+    KeyValue<String, OmKeyInfo> entry = iterator.seek(seekKeyInDb);
     int countEntries = 0;
     if (iterator.hasNext()) {
       if (entry.getKey().equals(keyArgs)) {
@@ -2188,7 +2189,7 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
-  public TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>> getDeletedDirEntries(
+  public TableIterator<String, ? extends KeyValue<String, OmKeyInfo>> getDeletedDirEntries(
       String volume, String bucket) throws IOException {
     Optional<String> bucketPrefix = getBucketPrefix(volume, bucket, true);
     return metadataManager.getDeletedDirTable().iterator(bucketPrefix.orElse(""));
@@ -2210,9 +2211,9 @@ public class KeyManagerImpl implements KeyManager {
         parentInfo.getObjectID(), "");
     long consumedSize = 0;
     boolean processedSubPaths = false;
-    try (TableIterator<String, ? extends Table.KeyValue<String, T>> iterator = table.iterator(seekFileInDB)) {
+    try (TableIterator<String, ? extends KeyValue<String, T>> iterator = table.iterator(seekFileInDB)) {
       while (iterator.hasNext() && remainingBufLimit > 0) {
-        Table.KeyValue<String, T> entry = iterator.next();
+        KeyValue<String, T> entry = iterator.next();
         T withParentObjectId = entry.getValue();
         long objectSerializedSize = entry.getRawSize();
         if (!OMFileRequest.isImmediateChild(withParentObjectId.getParentObjectID(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -704,9 +704,9 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
 
       locks = Stream.of(
           om.getKeyManager().getDeletingService(),
+          om.getKeyManager().getDirDeletingService(),
           om.getKeyManager().getSnapshotSstFilteringService(),
           om.getKeyManager().getSnapshotDeletingService(),
-          om.getKeyManager().getSnapshotDirectoryService(),
           om.getMetadataManager().getStore().getRocksDBCheckpointDiffer()
       )
           .filter(Objects::nonNull)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  *  of TrashPolicy ozone-specific trash optimizations are/will be made such as
  *  having a multithreaded TrashEmptier.
  */
-public class TrashPolicyOzone extends OzoneTrashPolicy {
+class TrashPolicyOzone extends OzoneTrashPolicy {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TrashPolicyOzone.class);
@@ -60,10 +60,7 @@ public class TrashPolicyOzone extends OzoneTrashPolicy {
       new SimpleDateFormat("yyMMddHHmm");
   private long emptierInterval;
 
-  private OzoneManager om;
-
-  public TrashPolicyOzone() {
-  }
+  private final OzoneManager om;
 
   @Override
   public void initialize(Configuration conf, FileSystem fs) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -720,6 +720,22 @@ public final class OMFileRequest {
     return null;
   }
 
+  public static OmKeyInfo getKeyInfoWithFullPath(OmKeyInfo parentInfo, OmDirectoryInfo directoryInfo) {
+    String dirName = OMFileRequest.getAbsolutePath(parentInfo.getKeyName(),
+        directoryInfo.getName());
+    return OMFileRequest.getOmKeyInfo(
+        parentInfo.getVolumeName(), parentInfo.getBucketName(), directoryInfo,
+        dirName);
+  }
+
+  public static OmKeyInfo getKeyInfoWithFullPath(OmKeyInfo parentInfo, OmKeyInfo omKeyInfo) {
+    omKeyInfo.setFileName(omKeyInfo.getKeyName());
+    String fullKeyPath = OMFileRequest.getAbsolutePath(
+        parentInfo.getKeyName(), omKeyInfo.getKeyName());
+    omKeyInfo.setKeyName(fullKeyPath);
+    return omKeyInfo;
+  }
+
   /**
    * Prepare OmKeyInfo from OmDirectoryInfo.
    *

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -384,6 +384,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
     int consumedSize = 0;
     while (subDirRecursiveCnt < allSubDirList.size() && remainingBufLimit > 0) {
       try {
+        LOG.info("Subdir deleting request: {}", subDirRecursiveCnt);
         Pair<String, OmKeyInfo> stringOmKeyInfoPair = allSubDirList.get(subDirRecursiveCnt++);
         Boolean subDirectoryReclaimable = reclaimableDirChecker.apply(Table.newKeyValue(stringOmKeyInfoPair.getKey(),
             stringOmKeyInfoPair.getValue()));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -384,7 +384,6 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
     int consumedSize = 0;
     while (subDirRecursiveCnt < allSubDirList.size() && remainingBufLimit > 0) {
       try {
-        LOG.info("Subdir deleting request: {}", subDirRecursiveCnt);
         Pair<String, OmKeyInfo> stringOmKeyInfoPair = allSubDirList.get(subDirRecursiveCnt++);
         Boolean subDirectoryReclaimable = reclaimableDirChecker.apply(Table.newKeyValue(stringOmKeyInfoPair.getKey(),
             stringOmKeyInfoPair.getValue()));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om.service;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -213,15 +214,11 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
     }
 
     private OzoneManagerProtocolProtos.SetSnapshotPropertyRequest getSetSnapshotRequestUpdatingExclusiveSize(
-        Map<UUID, Long> exclusiveSizeMap, Map<UUID, Long> exclusiveReplicatedSizeMap, UUID snapshotID) {
+        long exclusiveSize, long exclusiveReplicatedSize, UUID snapshotID) {
       OzoneManagerProtocolProtos.SnapshotSize snapshotSize = OzoneManagerProtocolProtos.SnapshotSize.newBuilder()
-          .setExclusiveSize(
-              exclusiveSizeMap.getOrDefault(snapshotID, 0L))
-          .setExclusiveReplicatedSize(
-              exclusiveReplicatedSizeMap.getOrDefault(
-                  snapshotID, 0L))
+          .setExclusiveSize(exclusiveSize)
+          .setExclusiveReplicatedSize(exclusiveReplicatedSize)
           .build();
-
       return OzoneManagerProtocolProtos.SetSnapshotPropertyRequest.newBuilder()
           .setSnapshotKey(snapshotChainManager.getTableKey(snapshotID))
           .setSnapshotSizeDeltaFromDirDeepCleaning(snapshotSize)
@@ -235,7 +232,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
      */
     private void processDeletedDirsForStore(SnapshotInfo currentSnapshotInfo, KeyManager keyManager,
         long remainingBufLimit, long rnCnt) throws IOException, ExecutionException, InterruptedException {
-      String volume, bucket, snapshotTableKey;
+      String volume, bucket; String snapshotTableKey;
       if (currentSnapshotInfo != null) {
         volume = currentSnapshotInfo.getVolumeName();
         bucket = currentSnapshotInfo.getBucketName();
@@ -244,47 +241,39 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
         volume = null; bucket = null; snapshotTableKey = null;
       }
 
-      OmSnapshotManager omSnapshotManager = getOzoneManager().getOmSnapshotManager();
-      IOzoneManagerLock lock = getOzoneManager().getMetadataManager().getLock();
-
       try (DeletedDirSupplier dirSupplier = new DeletedDirSupplier(currentSnapshotInfo == null ?
-          keyManager.getDeletedDirEntries() : keyManager.getDeletedDirEntries(volume, bucket));
-           ReclaimableDirFilter reclaimableDirFilter = new ReclaimableDirFilter(getOzoneManager(),
-               omSnapshotManager, snapshotChainManager, currentSnapshotInfo, keyManager, lock);
-           ReclaimableKeyFilter reclaimableFileFilter = new ReclaimableKeyFilter(getOzoneManager(),
-               omSnapshotManager, snapshotChainManager, currentSnapshotInfo, keyManager, lock)) {
+          keyManager.getDeletedDirEntries() : keyManager.getDeletedDirEntries(volume, bucket))) {
         // This is to avoid race condition b/w purge request and snapshot chain update. For AOS taking the global
         // snapshotId since AOS could process multiple buckets in one iteration. While using path
         // previous snapshotId for a snapshot since it would process only one bucket.
         UUID expectedPreviousSnapshotId = currentSnapshotInfo == null ?
             snapshotChainManager.getLatestGlobalSnapshotId() :
             SnapshotUtils.getPreviousSnapshotId(currentSnapshotInfo, snapshotChainManager);
+        Map<UUID, Pair<Long, Long>> exclusiveSizeMap = Maps.newConcurrentMap();
+
         CompletableFuture<Boolean> processedAllDeletedDirs = CompletableFuture.completedFuture(true);
         for (int i = 0; i < numberOfParallelThreadsPerStore; i++) {
-          CompletableFuture<Boolean> future = new CompletableFuture<>();
-          deletionThreadPool.submit(() -> {
+          CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
             try {
-              boolean processedAll = processDeletedDirectories(snapshotTableKey, dirSupplier, remainingBufLimit,
-                  reclaimableDirFilter, reclaimableFileFilter, expectedPreviousSnapshotId, rnCnt);
-              future.complete(processedAll);
+              return processDeletedDirectories(currentSnapshotInfo, keyManager, dirSupplier, remainingBufLimit,
+                  expectedPreviousSnapshotId, exclusiveSizeMap, rnCnt);
             } catch (Throwable e) {
-              future.complete(false);
+              return false;
             }
-          });
+          }, deletionThreadPool);
           processedAllDeletedDirs = future.thenCombine(future, (a, b) -> a && b);
         }
         // If AOS or all directories have been processed for snapshot, update snapshot size delta and deep clean flag
         // if it is a snapshot.
         if (processedAllDeletedDirs.get()) {
           List<OzoneManagerProtocolProtos.SetSnapshotPropertyRequest> setSnapshotPropertyRequests = new ArrayList<>();
-          Map<UUID, Long> exclusiveReplicatedSizeMap = reclaimableFileFilter.getExclusiveReplicatedSizeMap();
-          Map<UUID, Long> exclusiveSizeMap = reclaimableFileFilter.getExclusiveSizeMap();
-          List<UUID> previousPathSnapshotsInChain =
-              Stream.of(exclusiveSizeMap.keySet(), exclusiveReplicatedSizeMap.keySet())
-                  .flatMap(Collection::stream).distinct().collect(Collectors.toList());
-          for (UUID snapshot : previousPathSnapshotsInChain) {
-            setSnapshotPropertyRequests.add(getSetSnapshotRequestUpdatingExclusiveSize(exclusiveSizeMap,
-                exclusiveReplicatedSizeMap, snapshot));
+
+          for (Map.Entry<UUID, Pair<Long, Long>> entry : exclusiveSizeMap.entrySet()) {
+            UUID snapshotID = entry.getKey();
+            long exclusiveSize = entry.getValue().getLeft();
+            long exclusiveReplicatedSize = entry.getValue().getRight();
+            setSnapshotPropertyRequests.add(getSetSnapshotRequestUpdatingExclusiveSize(
+                exclusiveSize, exclusiveReplicatedSize, snapshotID));
           }
 
           // Updating directory deep clean flag of snapshot.
@@ -300,24 +289,30 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
     }
 
     /**
-     * Processes the directories marked as deleted and performs reclamation if applicable.
-     * This includes preparing and submitting requests to delete directories and their
-     * subdirectories/files while respecting buffer limits and snapshot constraints.
+     * Processes deleted directories for snapshot management, determining whether
+     * directories and files can be purged, and calculates exclusive size mappings
+     * for snapshots.
      *
-     * @param snapshotTableKey the key of the snapshot table to which the operation applies
-     * @param dirSupplier thread safe supplier to fetch the next directory marked as deleted.
-     * @param remainingBufLimit the limit for the remaining buffer size available for processing
-     * @param reclaimableDirFilter filter to determine whether a directory is reclaimable
-     * @param reclaimableFileFilter filter to determine whether a file is reclaimable
-     * @param expectedPreviousSnapshotId UUID of the expected previous snapshot in the snapshot chain
-     * @param runCount the current run count of the deletion process
-     * @return true if no purge requests were submitted (indicating no deletions processed),
-     *         false otherwise
+     * @param currentSnapshotInfo Information about the current snapshot whose deleted directories are being processed.
+     * @param keyManager Key manager of the underlying storage system to handle key operations.
+     * @param dirSupplier Supplier for fetching pending deleted directories to be processed.
+     * @param remainingBufLimit Remaining buffer limit for processing directories and files.
+     * @param expectedPreviousSnapshotId The UUID of the previous snapshot expected in the chain.
+     * @param totalExclusiveSizeMap A map for storing total exclusive size and exclusive replicated size
+     *                              for each snapshot.
+     * @param runCount The number of times the processing task has been executed.
+     * @return A boolean indicating whether the processed directory list is empty.
      */
-    private boolean processDeletedDirectories(String snapshotTableKey,
-        DeletedDirSupplier dirSupplier, long remainingBufLimit, ReclaimableDirFilter reclaimableDirFilter,
-        ReclaimableKeyFilter reclaimableFileFilter, UUID expectedPreviousSnapshotId, long runCount) {
-      try {
+    private boolean processDeletedDirectories(SnapshotInfo currentSnapshotInfo, KeyManager keyManager,
+        DeletedDirSupplier dirSupplier, long remainingBufLimit, UUID expectedPreviousSnapshotId,
+        Map<UUID, Pair<Long, Long>> totalExclusiveSizeMap, long runCount) {
+      OmSnapshotManager omSnapshotManager = getOzoneManager().getOmSnapshotManager();
+      IOzoneManagerLock lock = getOzoneManager().getMetadataManager().getLock();
+      String snapshotTableKey = currentSnapshotInfo == null ? null : currentSnapshotInfo.getTableKey();
+      try (ReclaimableDirFilter reclaimableDirFilter = new ReclaimableDirFilter(getOzoneManager(),
+          omSnapshotManager, snapshotChainManager, currentSnapshotInfo, keyManager, lock);
+          ReclaimableKeyFilter reclaimableFileFilter = new ReclaimableKeyFilter(getOzoneManager(),
+              omSnapshotManager, snapshotChainManager, currentSnapshotInfo, keyManager, lock)) {
         long startTime = Time.monotonicNow();
         long dirNum = 0L;
         long subDirNum = 0L;
@@ -355,6 +350,21 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
             startTime, remainingBufLimit, getOzoneManager().getKeyManager(),
             reclaimableDirFilter, reclaimableFileFilter, expectedPreviousSnapshotId,
             runCount);
+        Map<UUID, Long> exclusiveReplicatedSizeMap = reclaimableFileFilter.getExclusiveReplicatedSizeMap();
+        Map<UUID, Long> exclusiveSizeMap = reclaimableFileFilter.getExclusiveSizeMap();
+        List<UUID> previousPathSnapshotsInChain =
+            Stream.of(exclusiveSizeMap.keySet(), exclusiveReplicatedSizeMap.keySet())
+                .flatMap(Collection::stream).distinct().collect(Collectors.toList());
+        for (UUID snapshot : previousPathSnapshotsInChain) {
+          totalExclusiveSizeMap.compute(snapshot, (k, v) -> {
+            long exclusiveSize = exclusiveSizeMap.getOrDefault(snapshot, 0L);
+            long exclusiveReplicatedSize = exclusiveReplicatedSizeMap.getOrDefault(snapshot, 0L);
+            if (v == null) {
+              return Pair.of(exclusiveSize, exclusiveReplicatedSize);
+            }
+            return Pair.of(v.getLeft() + exclusiveSize, v.getRight() + exclusiveReplicatedSize);
+          });
+        }
 
         return purgePathRequestList.isEmpty();
       } catch (IOException e) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
@@ -204,7 +204,7 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
      * @param keyManager KeyManager of the underlying store.
      */
     private void processDeletedKeysForStore(SnapshotInfo currentSnapshotInfo, KeyManager keyManager,
-        int remainNum) throws IOException, InterruptedException {
+        int remainNum) throws IOException {
       String volume = null, bucket = null, snapshotTableKey = null;
       if (currentSnapshotInfo != null) {
         volume = currentSnapshotInfo.getVolumeName();
@@ -323,8 +323,8 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
               SnapshotUtils.getSnapshotInfo(getOzoneManager(), snapshotChainManager, snapshotId);
           if (snapInfo != null) {
             if (snapInfo.isDeepCleaned()) {
-              LOG.info("Snapshot {} has already been deep cleaned. Skipping the snapshot in this iteration.",
-                  snapInfo.getSnapshotId());
+              LOG.info("Snapshot {} has already been deep cleaned. Skipping the snapshot in this iteration. " +
+                      "Snapshot name : {}", snapInfo.getSnapshotId(), snapInfo.getName());
               return EmptyTaskResult.newResult();
             }
             if (!OmSnapshotManager.areSnapshotChangesFlushedToDB(getOzoneManager().getMetadataManager(), snapInfo)) {
@@ -345,7 +345,7 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
                 : omSnapshot.get().getKeyManager();
             processDeletedKeysForStore(snapInfo, keyManager, remainNum);
           }
-        } catch (IOException | InterruptedException e) {
+        } catch (IOException e) {
           LOG.error("Error while running delete files background task for store {}. Will retry at next run.",
               snapInfo, e);
         } finally {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -21,8 +21,8 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERV
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_DEEP_CLEANING_ENABLED;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_DIRECTORY_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -140,7 +140,7 @@ class TestKeyDeletingService extends OzoneTestBase {
   private KeyManager keyManager;
   private OMMetadataManager metadataManager;
   private KeyDeletingService keyDeletingService;
-  private SnapshotDirectoryCleaningService snapshotDirectoryCleaningService;
+  private DirectoryDeletingService directoryDeletingService;
   private ScmBlockLocationTestingClient scmBlockTestingClient;
 
   @BeforeAll
@@ -156,7 +156,7 @@ class TestKeyDeletingService extends OzoneTestBase {
         100, TimeUnit.MILLISECONDS);
     conf.setTimeDuration(OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL,
         100, TimeUnit.MILLISECONDS);
-    conf.setTimeDuration(OZONE_SNAPSHOT_DIRECTORY_SERVICE_INTERVAL,
+    conf.setTimeDuration(OZONE_DIR_DELETING_SERVICE_INTERVAL,
         100, TimeUnit.MILLISECONDS);
     conf.setTimeDuration(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
         1, TimeUnit.SECONDS);
@@ -170,7 +170,7 @@ class TestKeyDeletingService extends OzoneTestBase {
     OmTestManagers omTestManagers = new OmTestManagers(conf, scmBlockTestingClient, null);
     keyManager = omTestManagers.getKeyManager();
     keyDeletingService = keyManager.getDeletingService();
-    snapshotDirectoryCleaningService = keyManager.getSnapshotDirectoryService();
+    directoryDeletingService = keyManager.getDirDeletingService();
     writeClient = omTestManagers.getWriteClient();
     om = omTestManagers.getOzoneManager();
     metadataManager = omTestManagers.getMetadataManager();
@@ -524,6 +524,7 @@ class TestKeyDeletingService extends OzoneTestBase {
 
       // Suspend KeyDeletingService
       keyDeletingService.suspend();
+      directoryDeletingService.suspend();
 
       final long initialSnapshotCount = metadataManager.countRowsInTable(snapshotInfoTable);
       final long initialKeyCount = metadataManager.countRowsInTable(keyTable);
@@ -571,6 +572,7 @@ class TestKeyDeletingService extends OzoneTestBase {
       checkSnapDeepCleanStatus(snapshotInfoTable, volumeName, false);
 
       keyDeletingService.resume();
+      directoryDeletingService.resume();
 
       try (UncheckedAutoCloseableSupplier<OmSnapshot> rcOmSnapshot =
                om.getOmSnapshotManager().getSnapshot(volumeName, bucketName, snap3)) {
@@ -640,6 +642,7 @@ class TestKeyDeletingService extends OzoneTestBase {
 
       // Supspend KDS
       keyDeletingService.suspend();
+      directoryDeletingService.suspend();
 
       final long initialSnapshotCount = metadataManager.countRowsInTable(snapshotInfoTable);
       final long initialKeyCount = metadataManager.countRowsInTable(keyTable);
@@ -711,10 +714,11 @@ class TestKeyDeletingService extends OzoneTestBase {
       createAndCommitKey(testVolumeName, testBucketName, uniqueObjectName("key"), 3);
 
       long prevKdsRunCount = getRunCount();
-      long prevSnapshotDirectorServiceCnt = snapshotDirectoryCleaningService.getRunCount().get();
+      long prevSnapshotDirectorServiceCnt = directoryDeletingService.getRunCount().get();
+      directoryDeletingService.resume();
       // Let SnapshotDirectoryCleaningService to run for some iterations
       GenericTestUtils.waitFor(
-          () -> (snapshotDirectoryCleaningService.getRunCount().get() > prevSnapshotDirectorServiceCnt + 20),
+          () -> (directoryDeletingService.getRunCount().get() > prevSnapshotDirectorServiceCnt + 100),
           100, 100000);
       keyDeletingService.resume();
 
@@ -779,7 +783,7 @@ class TestKeyDeletingService extends OzoneTestBase {
 
     @Test
     @DisplayName("Should not update keys when purge request times out during key deletion")
-    public void testFailingModifiedKeyPurge() throws IOException, InterruptedException {
+    public void testFailingModifiedKeyPurge() throws IOException {
 
       try (MockedStatic<OzoneManagerRatisUtils> mocked =  mockStatic(OzoneManagerRatisUtils.class,
           CALLS_REAL_METHODS)) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/AbstractReclaimableFilterTest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/AbstractReclaimableFilterTest.java
@@ -48,12 +48,14 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
+import org.apache.hadoop.ozone.om.BucketManager;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
@@ -159,19 +161,28 @@ public abstract class AbstractReclaimableFilterTest {
 
   private void mockOzoneManager(BucketLayout bucketLayout) throws IOException {
     OMMetadataManager metadataManager = mock(OMMetadataManager.class);
+    BucketManager bucketManager = mock(BucketManager.class);
     when(ozoneManager.getMetadataManager()).thenReturn(metadataManager);
+    when(ozoneManager.getBucketManager()).thenReturn(bucketManager);
     long volumeCount = 0;
-    long bucketCount = 0;
     for (String volume : volumes) {
       when(metadataManager.getVolumeId(eq(volume))).thenReturn(volumeCount);
-      for (String bucket : buckets) {
-        when(ozoneManager.getBucketInfo(eq(volume), eq(bucket)))
-            .thenReturn(OmBucketInfo.newBuilder().setVolumeName(volume).setBucketName(bucket)
-                .setObjectID(bucketCount).setBucketLayout(bucketLayout).build());
-        bucketCount++;
-      }
       volumeCount++;
     }
+
+    when(bucketManager.getBucketInfo(anyString(), anyString())).thenAnswer(i -> {
+      String volume = i.getArgument(0, String.class);
+      String bucket = i.getArgument(1, String.class);
+      if (!volumes.contains(volume)) {
+        throw new OMException("Volume " + volume + " doesn't exist", OMException.ResultCodes.VOLUME_NOT_FOUND);
+      }
+      if (!buckets.contains(bucket)) {
+        throw new OMException("Bucket " + bucket + " doesn't exist", OMException.ResultCodes.BUCKET_NOT_FOUND);
+      }
+      return OmBucketInfo.newBuilder().setVolumeName(volume).setBucketName(bucket)
+          .setObjectID((long) volumes.indexOf(volume) * buckets.size() + buckets.indexOf(bucket))
+          .setBucketLayout(bucketLayout).build();
+    });
   }
 
   private void mockOmSnapshotManager(OzoneManager om) throws RocksDBException, IOException {
@@ -232,7 +243,7 @@ public abstract class AbstractReclaimableFilterTest {
 
   protected List<SnapshotInfo> getLastSnapshotInfos(
       String volume, String bucket, int numberOfSnapshotsInChain, int index) {
-    List<SnapshotInfo> infos = getSnapshotInfos().get(getKey(volume, bucket));
+    List<SnapshotInfo> infos = getSnapshotInfos().getOrDefault(getKey(volume, bucket), Collections.emptyList());
     int endIndex = Math.min(index - 1, infos.size() - 1);
     return IntStream.range(endIndex - numberOfSnapshotsInChain + 1, endIndex + 1).mapToObj(i -> i >= 0 ?
         infos.get(i) : null).collect(Collectors.toList());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/AbstractReclaimableFilterTest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/AbstractReclaimableFilterTest.java
@@ -48,12 +48,14 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
+import org.apache.hadoop.ozone.om.BucketManager;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
@@ -159,19 +161,28 @@ public abstract class AbstractReclaimableFilterTest {
 
   private void mockOzoneManager(BucketLayout bucketLayout) throws IOException {
     OMMetadataManager metadataManager = mock(OMMetadataManager.class);
+    BucketManager bucketManager = mock(BucketManager.class);
     when(ozoneManager.getMetadataManager()).thenReturn(metadataManager);
+    when(ozoneManager.getBucketManager()).thenReturn(bucketManager);
     long volumeCount = 0;
-    long bucketCount = 0;
     for (String volume : volumes) {
       when(metadataManager.getVolumeId(eq(volume))).thenReturn(volumeCount);
-      for (String bucket : buckets) {
-        when(ozoneManager.getBucketInfo(eq(volume), eq(bucket)))
-            .thenReturn(OmBucketInfo.newBuilder().setVolumeName(volume).setBucketName(bucket)
-                .setObjectID(bucketCount).setBucketLayout(bucketLayout).build());
-        bucketCount++;
-      }
       volumeCount++;
     }
+
+    when(bucketManager.getBucketInfo(anyString(), anyString())).thenAnswer(i -> {
+      String volume = i.getArgument(0, String.class);
+      String bucket = i.getArgument(1, String.class);
+      if (!volumes.contains(volume)) {
+        throw new OMException("Volume " + volume + " already exists", OMException.ResultCodes.VOLUME_NOT_FOUND);
+      }
+      if (!buckets.contains(bucket)) {
+        throw new OMException("Bucket " + bucket + " already exists", OMException.ResultCodes.BUCKET_NOT_FOUND);
+      }
+      return OmBucketInfo.newBuilder().setVolumeName(volume).setBucketName(bucket)
+          .setObjectID((long) volumes.indexOf(volume) * buckets.size() + buckets.indexOf(bucket))
+          .setBucketLayout(bucketLayout).build();
+    });
   }
 
   private void mockOmSnapshotManager(OzoneManager om) throws RocksDBException, IOException {
@@ -232,7 +243,7 @@ public abstract class AbstractReclaimableFilterTest {
 
   protected List<SnapshotInfo> getLastSnapshotInfos(
       String volume, String bucket, int numberOfSnapshotsInChain, int index) {
-    List<SnapshotInfo> infos = getSnapshotInfos().get(getKey(volume, bucket));
+    List<SnapshotInfo> infos = getSnapshotInfos().getOrDefault(getKey(volume, bucket), Collections.emptyList());
     int endIndex = Math.min(index - 1, infos.size() - 1);
     return IntStream.range(endIndex - numberOfSnapshotsInChain + 1, endIndex + 1).mapToObj(i -> i >= 0 ?
         infos.get(i) : null).collect(Collectors.toList());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableDirFilter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableDirFilter.java
@@ -72,7 +72,7 @@ public class TestReclaimableDirFilter extends AbstractReclaimableFilterTest {
     List<SnapshotInfo> snapshotInfos = getLastSnapshotInfos(volume, bucket, 1, index);
     assertEquals(snapshotInfos.size(), 1);
     SnapshotInfo prevSnapshotInfo = snapshotInfos.get(0);
-    OmBucketInfo bucketInfo = getOzoneManager().getBucketInfo(volume, bucket);
+    OmBucketInfo bucketInfo = getOzoneManager().getBucketManager().getBucketInfo(volume, bucket);
     long volumeId = getOzoneManager().getMetadataManager().getVolumeId(volume);
     KeyManager keyManager = getKeyManager();
     if (prevSnapshotInfo != null) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableFilter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableFilter.java
@@ -132,6 +132,36 @@ public class TestReclaimableFilter extends AbstractReclaimableFilterTest {
 
   @ParameterizedTest
   @MethodSource("testReclaimableFilterArguments")
+  public void testReclaimableFilterSnapshotChainInitializationWithInvalidVolume(
+      int numberOfPreviousSnapshotsFromChain, int actualNumberOfSnapshots)
+      throws IOException, RocksDBException {
+    SnapshotInfo currentSnapshotInfo =
+        setup(numberOfPreviousSnapshotsFromChain, actualNumberOfSnapshots, actualNumberOfSnapshots + 1, 4, 2);
+    String volume = "volume" + 6;
+    String bucket = getBuckets().get(1);
+    testSnapshotInitAndLocking(volume, bucket, numberOfPreviousSnapshotsFromChain, actualNumberOfSnapshots + 1,
+        currentSnapshotInfo, true, true);
+    testSnapshotInitAndLocking(volume, bucket, numberOfPreviousSnapshotsFromChain, actualNumberOfSnapshots + 1,
+        currentSnapshotInfo, false, true);
+  }
+
+  @ParameterizedTest
+  @MethodSource("testReclaimableFilterArguments")
+  public void testReclaimableFilterSnapshotChainInitializationWithInvalidBucket(
+      int numberOfPreviousSnapshotsFromChain, int actualNumberOfSnapshots)
+      throws IOException, RocksDBException {
+    SnapshotInfo currentSnapshotInfo =
+        setup(numberOfPreviousSnapshotsFromChain, actualNumberOfSnapshots, actualNumberOfSnapshots + 1, 4, 2);
+    String volume = getVolumes().get(3);
+    String bucket = "bucket" + 6;
+    testSnapshotInitAndLocking(volume, bucket, numberOfPreviousSnapshotsFromChain, actualNumberOfSnapshots + 1,
+        currentSnapshotInfo, true, true);
+    testSnapshotInitAndLocking(volume, bucket, numberOfPreviousSnapshotsFromChain, actualNumberOfSnapshots + 1,
+        currentSnapshotInfo, false, true);
+  }
+
+  @ParameterizedTest
+  @MethodSource("testReclaimableFilterArguments")
   public void testReclaimableFilterWithBucketVolumeMismatch(
       int numberOfPreviousSnapshotsFromChain, int actualNumberOfSnapshots, int index)
       throws IOException, RocksDBException {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableKeyFilter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableKeyFilter.java
@@ -101,7 +101,7 @@ public class TestReclaimableKeyFilter extends AbstractReclaimableFilterTest {
     List<SnapshotInfo> snapshotInfos = getLastSnapshotInfos(volume, bucket, 2, index);
     SnapshotInfo previousToPreviousSapshotInfo = snapshotInfos.get(0);
     SnapshotInfo prevSnapshotInfo = snapshotInfos.get(1);
-    OmBucketInfo bucketInfo = getOzoneManager().getBucketInfo(volume, bucket);
+    OmBucketInfo bucketInfo = getOzoneManager().getBucketManager().getBucketInfo(volume, bucket);
     long volumeId = getOzoneManager().getMetadataManager().getVolumeId(volume);
 
     UncheckedAutoCloseableSupplier<OmSnapshot> prevSnap = Optional.ofNullable(prevSnapshotInfo)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableRenameEntryFilter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableRenameEntryFilter.java
@@ -80,7 +80,7 @@ public class TestReclaimableRenameEntryFilter extends AbstractReclaimableFilterT
       throws IOException {
     List<SnapshotInfo> snapshotInfos = getLastSnapshotInfos(volume, bucket, 1, index);
     SnapshotInfo prevSnapshotInfo = snapshotInfos.get(0);
-    OmBucketInfo bucketInfo = getOzoneManager().getBucketInfo(volume, bucket);
+    OmBucketInfo bucketInfo = getOzoneManager().getBucketManager().getBucketInfo(volume, bucket);
     if (prevSnapshotInfo != null) {
       UncheckedAutoCloseableSupplier<OmSnapshot> prevSnap = Optional.ofNullable(prevSnapshotInfo)
           .map(info -> {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/BlockExistenceVerifier.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/BlockExistenceVerifier.java
@@ -56,6 +56,7 @@ public class BlockExistenceVerifier implements ReplicaVerifier {
     XceiverClientSpi client = null;
     try {
       Pipeline pipeline = Pipeline.newBuilder(keyLocation.getPipeline())
+          .setId(datanode.getID())
           .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
           .setNodes(Collections.singletonList(datanode))
           .setReplicaIndexes(Collections.singletonMap(datanode, replicaIndex))

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ContainerStateVerifier.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ContainerStateVerifier.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug.replicas;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Objects;
+import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ReadContainerResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.hdds.scm.XceiverClientSpi;
+import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+
+/**
+ * Verifies the state of a replica from the DN.
+ * [DELETED, UNHEALTHY, INVALID] are considered bad states.
+ */
+public class ContainerStateVerifier implements ReplicaVerifier {
+  private static final String CHECK_TYPE = "containerState";
+  private static final long DEFAULT_CONTAINER_CACHE_SIZE = 1000000;
+  private final ContainerOperationClient containerOperationClient;
+  private final XceiverClientManager xceiverClientManager;
+  // cache for container info and encodedToken from the SCM
+  private final Cache<Long, ContainerInfoToken> encodedTokenCache;
+
+  public ContainerStateVerifier(OzoneConfiguration conf, long containerCacheSize) throws IOException {
+    containerOperationClient = new ContainerOperationClient(conf);
+    xceiverClientManager = containerOperationClient.getXceiverClientManager();
+
+    if (containerCacheSize < 1) {
+      System.err.println("Invalid cache size provided: " + containerCacheSize +
+              ". Falling back to default: " + DEFAULT_CONTAINER_CACHE_SIZE);
+      containerCacheSize = DEFAULT_CONTAINER_CACHE_SIZE;
+    }
+    encodedTokenCache = CacheBuilder.newBuilder().maximumSize(containerCacheSize).build();
+  }
+
+  @Override
+  public String getType() {
+    return CHECK_TYPE;
+  }
+
+  @Override
+  public BlockVerificationResult verifyBlock(DatanodeDetails datanode, OmKeyLocationInfo keyLocation,
+                                             int replicaIndex) {
+    try {
+      StringBuilder replicaCheckMsg = new StringBuilder().append("Replica state is ");
+      boolean pass = false;
+
+      ContainerInfoToken containerInfoToken = getContainerInfoToken(keyLocation.getContainerID());
+      ContainerDataProto containerData = fetchContainerDataFromDatanode(datanode, keyLocation.getContainerID(),
+          keyLocation, replicaIndex, containerInfoToken);
+
+      if (containerData == null) {
+        return BlockVerificationResult.failIncomplete("No container data returned from DN.");
+      }
+      ContainerDataProto.State state = containerData.getState();
+      replicaCheckMsg.append(state.name());
+      if (areContainerAndReplicasInGoodState(state, containerInfoToken.getContainerState())) {
+        pass = true;
+      }
+      replicaCheckMsg.append(", Container state in SCM is ").append(containerInfoToken.getContainerState());
+
+      if (pass) {
+        return BlockVerificationResult.pass();
+      } else {
+        return BlockVerificationResult.failCheck(replicaCheckMsg.toString());
+      }
+    } catch (IOException e) {
+      if (e.getMessage().contains("ContainerID") && e.getMessage().contains("does not exist")) {
+        // if container "does not exist", mark it as failed instead of incomplete
+        return BlockVerificationResult.failCheck(e.getMessage());
+      }
+      return BlockVerificationResult.failIncomplete(e.getMessage());
+    }
+  }
+
+  private boolean areContainerAndReplicasInGoodState(ContainerDataProto.State replicaState,
+      HddsProtos.LifeCycleState containerState) {
+    return (replicaState != ContainerDataProto.State.UNHEALTHY &&
+        replicaState != ContainerDataProto.State.INVALID &&
+        replicaState != ContainerDataProto.State.DELETED &&
+        containerState != HddsProtos.LifeCycleState.DELETING &&
+        containerState != HddsProtos.LifeCycleState.DELETED);
+  }
+
+  private ContainerDataProto fetchContainerDataFromDatanode(DatanodeDetails dn, long containerId,
+                                                            OmKeyLocationInfo keyLocation, int replicaIndex,
+                                                            ContainerInfoToken containerInfoToken)
+      throws IOException {
+    XceiverClientSpi client = null;
+    ReadContainerResponseProto response;
+    try {
+      Pipeline pipeline = Pipeline.newBuilder(keyLocation.getPipeline())
+          .setId(dn.getID())
+          .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
+          .setNodes(Collections.singletonList(dn))
+          .setReplicaIndexes(Collections.singletonMap(dn, replicaIndex))
+          .build();
+      String encodedToken = containerInfoToken.getEncodedToken();
+
+      client = xceiverClientManager.acquireClientForReadData(pipeline);
+      response = ContainerProtocolCalls
+          .readContainer(client, containerId, encodedToken);
+    } finally {
+      if (client != null) {
+        xceiverClientManager.releaseClient(client, false);
+      }
+    }
+
+    if (!response.hasContainerData()) {
+      return null;
+    }
+    return response.getContainerData();
+  }
+
+  private ContainerInfoToken getContainerInfoToken(long containerId)
+      throws IOException {
+    ContainerInfoToken cachedData = encodedTokenCache.getIfPresent(containerId);
+    if (cachedData != null) {
+      return cachedData;
+    }
+    // Cache miss - fetch and store
+    ContainerInfo info = containerOperationClient.getContainer(containerId);
+    String encodeToken = containerOperationClient.getEncodedContainerToken(containerId);
+    cachedData = new ContainerInfoToken(info.getState(), encodeToken);
+    encodedTokenCache.put(containerId, cachedData);
+    return cachedData;
+  }
+
+  private static class ContainerInfoToken {
+    private HddsProtos.LifeCycleState state;
+    private final String encodedToken;
+
+    ContainerInfoToken(HddsProtos.LifeCycleState lifeState, String token) {
+      this.state = lifeState;
+      this.encodedToken = token;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ContainerInfoToken)) {
+        return false;
+      }
+      ContainerInfoToken key = (ContainerInfoToken) o;
+      return Objects.equals(state, key.state) &&
+          Objects.equals(encodedToken, key.encodedToken);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(state, encodedToken);
+    }
+
+    public HddsProtos.LifeCycleState getContainerState() {
+      return state;
+    }
+
+    public String getEncodedToken() {
+      return encodedToken;
+    }
+  }
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
@@ -67,6 +67,14 @@ public class ReplicasVerify extends Handler {
   @CommandLine.ArgGroup(exclusive = false, multiplicity = "1")
   private Verification verification;
 
+  @CommandLine.Option(names = {"--container-cache-size"},
+      description = "Size (in number of containers) of the in-memory cache for container state verification " +
+          "'--container-state'. Default is 1 million containers (which takes around 43MB). " +
+          "Value must be greater than zero, otherwise the default of 1 million is considered. " +
+          "Note: This option is ignored if '--container-state' option is not used.",
+      defaultValue = "1000000")
+  private long containerCacheSize;
+
   private List<ReplicaVerifier> replicaVerifiers;
 
   @Override
@@ -79,6 +87,9 @@ public class ReplicasVerify extends Handler {
 
     if (verification.doExecuteBlockExistence) {
       replicaVerifiers.add(new BlockExistenceVerifier(getConf()));
+    }
+    if (verification.doExecuteReplicaState) {
+      replicaVerifiers.add(new ContainerStateVerifier(getConf(), containerCacheSize));
     }
 
     findCandidateKeys(client, address);
@@ -221,6 +232,13 @@ public class ReplicasVerify extends Handler {
         description = "Check for block existence on datanodes.",
         defaultValue = "false")
     private boolean doExecuteBlockExistence;
+
+    @CommandLine.Option(names = "--container-state",
+        description = "Check the container and replica states. " +
+            "Containers in [DELETING, DELETED] states, or " +
+            "it's replicas in [DELETED, UNHEALTHY, INVALID] states fail the check.",
+        defaultValue = "false")
+    private boolean doExecuteReplicaState;
 
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkKeyHandler.java
@@ -196,7 +196,7 @@ public class ChunkKeyHandler extends KeyHandler {
               // e.g. for RS-3-2 we will have data indexes 1,2,3 and parity indexes 4,5
               ChunkType chunkType = (replicaIndex > dataCount) ? ChunkType.PARITY : ChunkType.DATA;
               jsonObj.put("chunkType", chunkType.name());
-              jsonObj.put("ecIndex", replicaIndex);
+              jsonObj.put("replicaIndex", replicaIndex);
             }
           }
         } catch (InterruptedException e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
With implementation of ReclaimableKeyFilter & ReclaimableDirectoryFilter both snapshot directory deep cleaning and AOS DirectoryDeletingService can be unified which will simplify the entire implementation rather than having multiple implementations for DirectoryDeletingService. 
Algorithm in play:

1. The directory deleting service would be iterate through all the entries in the deletedDirectoryTable for a store(AOS and snapshot). One thread processing deleted directory entry for a particular store.
2. This thread would further initialize a DeletedDirectorySupplier which is an implementation for thread safe table iterator(We can eventually use a TableSpliterator after #8203 gets merged).
3. Each thread here would be iterating through the deletedDirectoryTable independently and would submit purgeDirectoriesRequests where the logic for directoryPurge is as follows:
               -  Check if the deletedDirectory object from deletedDirectoryTable can be reclaimed as in check if the reference       for directory object exists in the previous directory.
               - If the directory exists in the previous snapshot then we need not expand the sub files inside the files[Number of files would be a lot generally (number of files >>> number of directories)] and we would just expand all the subdirectories under the directory(this would help in the recursively iterating on the sub files in the next iteration instead of traversing again from root all over). Now we cannot purge the directories as a reference exists we would just move all sub directories present in the AOS directory table and files which can be reclaimed i.e. files which are not present in the previous snapshot's fileTable by iterating through the sub file list based on deleted directory prefix in the AOS file table and move it to the deleted space of the store[Check #8509].
               - If the directory doesn't exist in the previous snapshot we have to blindly remove all entries[sub files & sub directories] inside this directory irrespective whether it can be reclaimed or not and purge the directory if all the entries are going to be moved from AOS to the specific store's deleted space of the store.

4. Now once all threads have processed if none of the threads have been able to move any entry from the key space to deleted space(All keys already have been reclaimed in the previous run) we can go ahead update the exclusive size of the previous snapshot and the deep clean flag of the snapshot.                                

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13034

## How was this patch tested?
Existing unit tests and additional assertions added on existing tests.
