### PR TITLE
HDDS-13208. [Docs] Add volume management section under Architecture/Datanodes.

### DIFF
--- a/hadoop-hdds/docs/content/concept/Datanodes.md
+++ b/hadoop-hdds/docs/content/concept/Datanodes.md
@@ -122,4 +122,3 @@ hdds.datanode.dir | none | Determines where HDDS data will be stored on the loca
 hdds.datanode.dir.du.reserved | none | Reserved space in bytes per volume. Always leave this much space free for non dfs use.
 ozone.metadata.dirs | none | Directory to store persisted data (RocksDB).
 ozone.recon.address | 0.0.0.0:9891 | RPC address of the Recon. Use <host:port> to connect Recon.
-

--- a/hadoop-hdds/docs/content/concept/Datanodes.md
+++ b/hadoop-hdds/docs/content/concept/Datanodes.md
@@ -77,13 +77,13 @@ This extra indirection helps tremendously with scaling Ozone. SCM has far
 less block data to process and the namespace service (Ozone Manager) as a
 different service are critical to scaling Ozone.
 
-## Volume Management
+## Data Volume Management
 
 ### What is a Volume?
 
 In the context of an Ozone DataNode, a "volume" refers to a physical disk or storage device managed by the DataNode. Each volume can store many containers, which are the fundamental units of storage in Ozone. This is different from the "volume" concept in Ozone Manager, which refers to a namespace for organizing buckets and keys.
 
-The status of volumes, including used space, available space and whether or not they are operational or removed, can be looked up from DataNode Web UI.
+The status of volumes, including used space, available space and whether or not they are operational (healthy) or failed, can be looked up from DataNode Web UI.
 
 ### Defining Volumes with hdds.datanode.dir
 

--- a/hadoop-hdds/docs/content/concept/Datanodes.md
+++ b/hadoop-hdds/docs/content/concept/Datanodes.md
@@ -110,7 +110,7 @@ When a DataNode needs to select a volume to store new data, it uses a volume cho
 
 ### Disk Balancer
 
-Over time, operations like adding or replacing disks can cause uneven disk usage. The Ozone community is developing a Disk Balancer (see HDDS-5713) to automatically balance disk usage across DataNode volumes. This feature is under active development.
+Over time, operations like adding or replacing disks can cause uneven disk usage. The Ozone community is developing a Disk Balancer (see [HDDS-5713](https://issues.apache.org/jira/browse/HDDS-5713)) to automatically balance disk usage across DataNode volumes. This feature is under active development.
 
 ## Notable configurations
 

--- a/hadoop-hdds/docs/content/concept/Datanodes.md
+++ b/hadoop-hdds/docs/content/concept/Datanodes.md
@@ -102,11 +102,11 @@ When a DataNode needs to select a volume to store new data, it uses a volume cho
 
 ### Volume-Related Configuration Properties
 
-| Property Name                                 | Default Value                        | Description                                                                                  |
-|-----------------------------------------------|--------------------------------------|----------------------------------------------------------------------------------------------|
-| hdds.datanode.volume.choosing.policy          | CapacityVolumeChoosingPolicy          | The policy used to select a volume for new containers.                                       |
-| hdds.datanode.volume.min.free.space           | 10GB                                 | Minimum free space required on a volume to be eligible for new containers.                   |
-| hdds.datanode.volume.min.free.space.percent   | 15                                   | Minimum free space percentage required on a volume to be eligible for new containers.        |
+| Property Name                                 | Default Value                | Description                                                                                  |
+|-----------------------------------------------|------------------------------|----------------------------------------------------------------------------------------------|
+| hdds.datanode.volume.choosing.policy          | CapacityVolumeChoosingPolicy | The policy used to select a volume for new containers.                                       |
+| hdds.datanode.volume.min.free.space           | 20GB                         | Minimum free space required on a volume to be eligible for new containers.                   |
+| hdds.datanode.volume.min.free.space.percent   | 0.0001f                      | Minimum free space percentage required on a volume to be eligible for new containers.        |
 
 ### Disk Balancer
 

--- a/hadoop-hdds/docs/content/concept/Datanodes.md
+++ b/hadoop-hdds/docs/content/concept/Datanodes.md
@@ -77,6 +77,40 @@ This extra indirection helps tremendously with scaling Ozone. SCM has far
 less block data to process and the namespace service (Ozone Manager) as a
 different service are critical to scaling Ozone.
 
+## Volume Management
+
+### What is a Volume?
+
+In the context of an Ozone DataNode, a "volume" refers to a physical disk or storage device managed by the DataNode. Each volume can store many containers, which are the fundamental units of storage in Ozone. This is different from the "volume" concept in Ozone Manager, which refers to a namespace for organizing buckets and keys.
+
+The status of volumes, including used space, available space and whether or not they are operational or removed, can be looked up from DataNode Web UI.
+
+### Defining Volumes with hdds.datanode.dir
+
+The property `hdds.datanode.dir` defines the set of volumes (disks) managed by a DataNode. You can specify one or more directories, separated by commas. Each directory represents a volume.
+For example: `/data1/disk1,/data2/disk2`, which configures the DataNode to manage two volumes.
+
+### Volume Choosing Policy
+
+When a DataNode needs to select a volume to store new data, it uses a volume choosing policy. The policy is controlled by the property `hdds.datanode.volume.choosing.policy`. There are two main policies:
+
+- **CapacityVolumeChoosingPolicy (default):**
+  This policy randomly selects two volumes with enough available space and chooses the one with lower utilization (i.e., more free space). This approach increases the likelihood that less-used disks are chosen, helping to balance disk usage over time.
+
+- **RoundRobinVolumeChoosingPolicy:**
+  This policy selects volumes in a round-robin order, cycling through all available volumes. It does not consider the current utilization of each disk, but ensures even distribution of new containers across all disks.
+
+### Volume-Related Configuration Properties
+
+| Property Name                                 | Default Value                        | Description                                                                                  |
+|-----------------------------------------------|--------------------------------------|----------------------------------------------------------------------------------------------|
+| hdds.datanode.volume.choosing.policy          | CapacityVolumeChoosingPolicy          | The policy used to select a volume for new containers.                                       |
+| hdds.datanode.volume.min.free.space           | 10GB                                 | Minimum free space required on a volume to be eligible for new containers.                   |
+| hdds.datanode.volume.min.free.space.percent   | 15                                   | Minimum free space percentage required on a volume to be eligible for new containers.        |
+
+### Disk Balancer
+
+Over time, operations like adding or replacing disks can cause uneven disk usage. The Ozone community is developing a Disk Balancer (see HDDS-5713) to automatically balance disk usage across DataNode volumes. This feature is under active development.
 
 ## Notable configurations
 
@@ -88,3 +122,4 @@ hdds.datanode.dir | none | Determines where HDDS data will be stored on the loca
 hdds.datanode.dir.du.reserved | none | Reserved space in bytes per volume. Always leave this much space free for non dfs use.
 ozone.metadata.dirs | none | Directory to store persisted data (RocksDB).
 ozone.recon.address | 0.0.0.0:9891 | RPC address of the Recon. Use <host:port> to connect Recon.
+

--- a/hadoop-hdds/docs/content/concept/Datanodes.md
+++ b/hadoop-hdds/docs/content/concept/Datanodes.md
@@ -106,7 +106,7 @@ When a DataNode needs to select a volume to store new data, it uses a volume cho
 |-----------------------------------------------|------------------------------|----------------------------------------------------------------------------------------------|
 | hdds.datanode.volume.choosing.policy          | CapacityVolumeChoosingPolicy | The policy used to select a volume for new containers.                                       |
 | hdds.datanode.volume.min.free.space           | 20GB                         | Minimum free space required on a volume to be eligible for new containers.                   |
-| hdds.datanode.volume.min.free.space.percent   | 0.0001f                      | Minimum free space percentage required on a volume to be eligible for new containers.        |
+| hdds.datanode.volume.min.free.space.percent   | 0.001f                       | Minimum free space percentage required on a volume to be eligible for new containers.        |
 
 ### Disk Balancer
 

--- a/hadoop-hdds/docs/content/concept/Datanodes.md
+++ b/hadoop-hdds/docs/content/concept/Datanodes.md
@@ -106,7 +106,7 @@ When a DataNode needs to select a volume to store new data, it uses a volume cho
 |-----------------------------------------------|------------------------------|----------------------------------------------------------------------------------------------|
 | hdds.datanode.volume.choosing.policy          | CapacityVolumeChoosingPolicy | The policy used to select a volume for new containers.                                       |
 | hdds.datanode.volume.min.free.space           | 20GB                         | Minimum free space required on a volume to be eligible for new containers.                   |
-| hdds.datanode.volume.min.free.space.percent   | 0.001f                       | Minimum free space percentage required on a volume to be eligible for new containers.        |
+| hdds.datanode.volume.min.free.space.percent   | 0.001                        | Minimum free space percentage required on a volume to be eligible for new containers.        |
 
 ### Disk Balancer
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-13208. [Docs] Add volume management section under Architecture/Datanodes.

Please describe your PR in detail:
* Draft was generated by Copilot Agent (Preview) using prompt:
```
I tried to find any reference to volumes in an Ozone Datanode, but couldn't find any.

https://ozone.apache.org/docs/edge/concept/datanodes.html

I want to add a section "Volume management" in Datanodes.md

We should
(1) explain what a volume is in the context of Ozone DataNode; do not confuse it with namespace volumes in Ozone Manager. That a "volume" is essentially a disk, and a volume stores many containers.
(2) I wanted to also add descriptions for volume choosing policy. Find the description for the property hdds.datanode.volume.choosing.policy. There are two policies: CapacityVolumeChoosingPolicy (default) and RoundRobinVolumeChoosingPolicy. Use the source code as the source of truth to explain what they do and how they work.
(3) Create a table to include configuration properties related to volumes. Include default values and descriptions.
(3) Add a disk balancer description – while volume choosing policy is useful, cluster operations can result in imbalanced disks. For example, in scenarios that we need to add new disks or to replace broken disks, the datanode's disks usage becomes uneven Ozone community is developing a new feature 'disk balancer' that aims to balance disks of Datanodes. The feature is under development of [HDDS-5713](https://issues.apache.org/jira/browse/HDDS-5713), and is coming soon.
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13208

## How was this patch tested?

User doc