### PR TITLE
HDDS-13234. Expired secret key can abort leader OM startup.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -56,7 +56,6 @@ import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.HadoopKerberosName;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Daemon;
-import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -513,7 +513,11 @@ public class OzoneDelegationTokenSecretManager
     LOG.info("Loading token state into token manager.");
     for (Map.Entry<OzoneTokenIdentifier, Long> entry :
         state.getTokenState().entrySet()) {
-      addPersistedDelegationToken(entry.getKey(), entry.getValue());
+      try {
+        addPersistedDelegationToken(entry.getKey(), entry.getValue());
+      } catch (Exception e) {
+        LOG.error("exception while loading delegation token from DB... ignored to continue startup", e);
+      }
     }
   }
 
@@ -528,6 +532,10 @@ public class OzoneDelegationTokenSecretManager
     byte[] password;
     if (StringUtils.isNotEmpty(identifier.getSecretKeyId())) {
       ManagedSecretKey signKey = secretKeyClient.getSecretKey(UUID.fromString(identifier.getSecretKeyId()));
+      if (signKey == null) {
+        throw new IOException("Secret key " + UUID.fromString(identifier.getSecretKeyId()) +
+            " not found for token " + formatTokenId(identifier));
+      }
       password = signKey.sign(identifier.getBytes());
     } else {
       if (LOG.isDebugEnabled()) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -26,8 +26,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -78,11 +82,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.event.Level;
 
-
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 /**
  * Test class for {@link OzoneDelegationTokenSecretManager}.
  */


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-13234. Expired secret key can abort leader OM startup.

Please describe your PR in detail:
This pull request enhances error handling and introduces a new test case to improve the robustness of the `OzoneDelegationTokenSecretManager` class. Key changes include adding exception handling during token loading, validating secret keys, and testing scenarios with expired secret keys.

### Error Handling Enhancements:
* **Improved token loading resilience**: Added a try-catch block in `loadTokenSecretState` to log and ignore exceptions when loading delegation tokens from the database during startup. This ensures the service continues to start even if some tokens fail to load. (`hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java`, [hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.javaR516-R520](diffhunk://#diff-c1a9d39e4832292a5f5139203e1426f68cb80cfe2c3dce5966341eab99de008cR516-R520))
* **Secret key validation**: Added a check in `addPersistedDelegationToken` to throw an `IOException` if a secret key is not found for a token, preventing potential issues with invalid tokens. (`hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java`, [hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.javaR535-R538](diffhunk://#diff-c1a9d39e4832292a5f5139203e1426f68cb80cfe2c3dce5966341eab99de008cR535-R538))

### Testing Improvements:
* **Mocking utilities**: Imported Mockito utilities (`spy`, `doReturn`, `verify`, etc.) to facilitate mocking and verification in tests. (`hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java`, [hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.javaR81-R85](diffhunk://#diff-d5493ca2188ab1f10c0d97d02b4873ee4bc6c55ca2d5ac3b360498a94579d7dbR81-R85))
* **Expired secret key test case**: Added a new test, `testExpiredSecretKey`, to simulate scenarios where a secret key is unavailable (e.g., expired or missing). This ensures the system handles such cases gracefully and validates the secret key retrieval logic. (`hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java`, [hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.javaR239-R259](diffhunk://#diff-d5493ca2188ab1f10c0d97d02b4873ee4bc6c55ca2d5ac3b360498a94579d7dbR239-R259))

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13234

(Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Unit test
