### PR TITLE
HDDS-2453. Add Freon tests for S3 MPU Keys

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/freon.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/freon.robot
@@ -39,7 +39,20 @@ Freon S3BG
     ${result} =        Execute          ozone freon s3bg -e ${ENDPOINT_URL} -t ${threads} -n ${n} -p ${prefix} ${args}
                        Should contain   ${result}       Successful executions: ${n}
 
+Freon S3KG
+    [arguments]    ${prefix}=s3kg    ${n}=100    ${threads}=10   ${args}=${EMPTY}
+    ${result} =        Execute          ozone freon s3kg -e ${ENDPOINT_URL} -t ${threads} -n ${n} -p ${prefix} --bucket ${BUCKET} ${args}
+                       Should contain   ${result}       Successful executions: ${n}
+
 *** Test Cases ***
 Run Freon S3BG
     [Setup]    Setup aws credentials
     Freon S3BG   s3bg-${BUCKET}
+
+Run Freon S3KG
+    [Setup]    Setup aws credentials
+    Freon S3KG   s3kg-${BUCKET}
+
+Run Freon S3KG MPU
+    [Setup]    Setup aws credentials
+    Freon S3KG   s3kg-mpu-${BUCKET}  10  1  --multi-part-upload --parts=2 --size=5242880

--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/S3KeyGenerator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/S3KeyGenerator.java
@@ -73,7 +73,7 @@ public class S3KeyGenerator extends S3EntityGenerator
   private int fileSize;
 
   @Option(names = {"--multi-part-upload"},
-      description = "User multi part upload",
+      description = "Use multi-part upload",
       defaultValue = "false")
   private boolean multiPart;
 

--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/S3KeyGenerator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/S3KeyGenerator.java
@@ -77,11 +77,6 @@ public class S3KeyGenerator extends S3EntityGenerator
       defaultValue = "false")
   private boolean multiPart;
 
-  @Option(names = {"--mpu-key-uploads"},
-      description = "User multi part upload for key uploads",
-      defaultValue = "false")
-  private boolean mpuKeyUploads;
-
   @Option(names = {"--parts"},
       description = "Number of parts for multipart upload (final size = "
           + "--size * --parts)",
@@ -107,49 +102,9 @@ public class S3KeyGenerator extends S3EntityGenerator
     timer = getMetrics().timer("key-create");
 
     System.setProperty(DISABLE_PUT_OBJECT_MD5_VALIDATION_PROPERTY, "true");
-    if (mpuKeyUploads) {
-      runTests(this::createMpuKey);
-    } else {
-      runTests(this::createKey);
-    }
-
+    runTests(this::createKey);
 
     return null;
-  }
-
-  private void createMpuKey(long counter) throws Exception {
-    timer.time(() -> {
-      final String keyName = generateObjectName(counter);
-      final InitiateMultipartUploadRequest initiateRequest =
-          new InitiateMultipartUploadRequest(bucketName, keyName);
-
-      final InitiateMultipartUploadResult initiateMultipartUploadResult =
-          getS3().initiateMultipartUpload(initiateRequest);
-      final String uploadId = initiateMultipartUploadResult.getUploadId();
-
-      List<PartETag> parts = new ArrayList<>();
-      for (int i = 1; i <= numberOfParts; i++) {
-
-        final UploadPartRequest uploadPartRequest = new UploadPartRequest()
-            .withBucketName(bucketName)
-            .withKey(keyName)
-            .withPartNumber(i)
-            .withLastPart(i == numberOfParts)
-            .withUploadId(uploadId)
-            .withPartSize(fileSize)
-            .withInputStream(new ByteArrayInputStream(content.getBytes(
-                StandardCharsets.UTF_8)));
-
-        final UploadPartResult uploadPartResult =
-            getS3().uploadPart(uploadPartRequest);
-        parts.add(uploadPartResult.getPartETag());
-      }
-
-      getS3().completeMultipartUpload(
-          new CompleteMultipartUploadRequest(bucketName, keyName, uploadId,
-              parts));
-      return null;
-    });
   }
 
   private void createKey(long counter) throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-2453. Add Freon tests for S3 MPU Keys

Please describe your PR in detail:
* S3 bucket freon test is already implemented.
* MPU key write can be added on the existing S3 key write freon test.
* Added robot test for S3 key writes

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2453

## How was this patch tested?

Robot tests